### PR TITLE
add cmath include

### DIFF
--- a/examples/DynamicBuffers/src/app.cpp
+++ b/examples/DynamicBuffers/src/app.cpp
@@ -28,6 +28,7 @@
 
 
 #include <string>
+#include <cmath>
 #include "misc/glsl_to_spirv.h"
 #include "misc/io.h"
 #include "misc/memory_allocator.h"

--- a/examples/MultiViewport/src/app.cpp
+++ b/examples/MultiViewport/src/app.cpp
@@ -27,6 +27,7 @@
 // #define ENABLE_VALIDATION
 
 #include <string>
+#include <cmath>
 #include "misc/glsl_to_spirv.h"
 #include "misc/memory_allocator.h"
 #include "misc/object_tracker.h"

--- a/examples/PushConstants/src/app.cpp
+++ b/examples/PushConstants/src/app.cpp
@@ -27,6 +27,7 @@
 // #define ENABLE_VALIDATION
 
 #include <string>
+#include <cmath>
 #include "misc/glsl_to_spirv.h"
 #include "misc/io.h"
 #include "misc/memory_allocator.h"


### PR DESCRIPTION
I need this to compile the examples on gcc 6.3.1.

Error message without cmath included:
```
/home/chris/build/Anvil/examples/DynamicBuffers/src/app.cpp: In member function 'void App::init_buffers()':
/home/chris/build/Anvil/examples/DynamicBuffers/src/app.cpp:458:78: error: 'cos' was not declared in this scope
         *color_buffer_data_traveller_ptr= (unsigned char)((cos(float(n_sine) ) * 0.5f + 0.5f) * 255.0f);
                                                                              ^
/home/chris/build/Anvil/examples/DynamicBuffers/src/app.cpp:461:79: error: 'sin' was not declared in this scope
         *color_buffer_data_traveller_ptr = (unsigned char)((sin(float(n_sine) ) * 0.5f + 0.5f) * 255.0f);
                                                                               ^
```

I have not tested it on any other compiler.