### PR TITLE
Treat `deps/` as system includes to suppres warnings in external code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,10 @@ option(ANVIL_LINK_WITH_GLSLANG "Links with glslang, instead of spawning a new pr
 # Do not modify anything after this line, unless you know what you're doing.
 configure_file("include/config.h.in" "${Anvil_SOURCE_DIR}/include/config.h")
 
-include_directories("$(Anvil_SOURCE_DIR)/deps"
-                    "$(Anvil_SOURCE_DIR)/include")
+# This is temporary until miniz can be compiled with all the warnings enabled. PRs were submitted to upstream project.
+include_directories(SYSTEM "$(Anvil_SOURCE_DIR)/deps")
+
+include_directories("$(Anvil_SOURCE_DIR)/include")
 
 if (WIN32)
     include_directories($ENV{VK_SDK_PATH}/Include


### PR DESCRIPTION
A better version of #9 which treats code in `deps/` as system libraries causing GCC and the like to suppress warnings in this code.

This is only until `miniz` gets fixed upstream - PR was opened and the strict aliasing violation has been reported.