### PR TITLE
Fix MSYS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ else()
     endif()
 endif()
 
-if (NOT WIN32)
+if (NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive -std=c++11")
 else()
     set(CMAKE_CXX_FLAGS "$(CMAKE_CXX_FLAGS) /EHsc /MP")

--- a/deps/miniz/miniz.c
+++ b/deps/miniz/miniz.c
@@ -157,7 +157,7 @@
 */
 
 /* This miniz version has been modified in order not to generate any warnings  */
-#ifdef _WIN32
+#ifdef _MSC_VER
     #pragma warning(push, 0)
 #else
     #pragma GCC diagnostic push
@@ -1505,7 +1505,14 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
       {
         mz_uint8 *p = r->m_tables[0].m_code_size; mz_uint i;
         r->m_table_sizes[0] = 288; r->m_table_sizes[1] = 32; TINFL_MEMSET(r->m_tables[1].m_code_size, 5, 32);
-        for ( i = 0; i <= 143; ++i) *p++ = 8; for ( ; i <= 255; ++i) *p++ = 9; for ( ; i <= 279; ++i) *p++ = 7; for ( ; i <= 287; ++i) *p++ = 8;
+        for ( i = 0; i <= 143; ++i)
+			*p++ = 8;
+		for ( ; i <= 255; ++i)
+			*p++ = 9;
+		for ( ; i <= 279; ++i)
+			*p++ = 7;
+		for ( ; i <= 287; ++i)
+			*p++ = 8;
       }
       else
       {
@@ -2289,7 +2296,10 @@ static MZ_FORCEINLINE void tdefl_find_match(tdefl_compressor *d, mz_uint lookahe
         if (TDEFL_READ_UNALIGNED_WORD(&d->m_dict[probe_pos + match_len - 1]) == c01) break;
       TDEFL_PROBE; TDEFL_PROBE; TDEFL_PROBE;
     }
-    if (!dist) break; q = (const mz_uint16*)(d->m_dict + probe_pos); if (TDEFL_READ_UNALIGNED_WORD(q) != s01) continue; p = s; probe_len = 32;
+    if (!dist) break;
+	q = (const mz_uint16*)(d->m_dict + probe_pos);
+	if (TDEFL_READ_UNALIGNED_WORD(q) != s01) continue;
+	p = s; probe_len = 32;
     do { } while ( (TDEFL_READ_UNALIGNED_WORD(++p) == TDEFL_READ_UNALIGNED_WORD(++q)) && (TDEFL_READ_UNALIGNED_WORD(++p) == TDEFL_READ_UNALIGNED_WORD(++q)) &&
                    (TDEFL_READ_UNALIGNED_WORD(++p) == TDEFL_READ_UNALIGNED_WORD(++q)) && (TDEFL_READ_UNALIGNED_WORD(++p) == TDEFL_READ_UNALIGNED_WORD(++q)) && (--probe_len > 0) );
     if (!probe_len)
@@ -4896,7 +4906,7 @@ void *mz_zip_extract_archive_file_to_heap(const char *pZip_filename, const char 
 
 #endif // MINIZ_HEADER_FILE_ONLY
 
-#ifdef _WIN32
+#ifdef _MSC_VER
     #pragma warning(pop)
 #else
     #pragma GCC diagnostic pop

--- a/include/misc/glsl_to_spirv.h
+++ b/include/misc/glsl_to_spirv.h
@@ -37,7 +37,7 @@
 #include <vector>
 
 #ifdef ANVIL_LINK_WITH_GLSLANG
-    #ifdef _WIN32
+    #ifdef _MSC_VER
         #pragma warning(push)
         #pragma warning(disable: 4619)
         #pragma warning(disable: 4464)
@@ -45,7 +45,7 @@
 
     #include "../../deps/glslang/glslang/Public/ShaderLang.h"
 
-    #ifdef _WIN32
+    #ifdef _MSC_VER
         #pragma warning(pop)
     #endif
 #endif

--- a/include/misc/types.h
+++ b/include/misc/types.h
@@ -22,11 +22,12 @@
 
 #ifndef MISC_TYPES_H
 #define MISC_TYPES_H
+#include <cstdio>
 
 /* Disable some of the warnings we cannot work around because they are caused
  * by external dependencies (ie. Vulkan header)
  */
-#ifdef _WIN32
+#ifdef _MSC_VER
     #pragma warning(disable : 4063)
 #else
     #pragma GCC diagnostic ignored "-Wswitch"

--- a/src/misc/glsl_to_spirv.cpp
+++ b/src/misc/glsl_to_spirv.cpp
@@ -36,7 +36,7 @@
 #ifdef ANVIL_LINK_WITH_GLSLANG
     #undef snprintf
 
-    #if defined(_WIN32)
+    #if defined(_MSC_VER)
         #pragma warning(push)
         #pragma warning(disable: 4100)
         #pragma warning(disable: 4365)
@@ -45,7 +45,7 @@
 
     #include "glslang/SPIRV/GlslangToSpv.h"
 
-    #ifdef _WIN32
+    #ifdef _MSC_VER
         #pragma warning(pop)
     #endif
 #endif

--- a/src/misc/window_win3264.cpp
+++ b/src/misc/window_win3264.cpp
@@ -199,7 +199,6 @@ LRESULT CALLBACK Anvil::WindowWin3264::msg_callback_pfn_proc(HWND   window_handl
 void Anvil::WindowWin3264::run()
 {
     int done   = 0;
-    //int result = 0;
 
     /* Run the message loop */
     while (!done)
@@ -215,7 +214,6 @@ void Anvil::WindowWin3264::run()
         if (msg.message == WM_QUIT)
         {
             done   = 1;
-            //result = (int) msg.wParam;
         }
         else
         {

--- a/src/misc/window_win3264.cpp
+++ b/src/misc/window_win3264.cpp
@@ -199,7 +199,7 @@ LRESULT CALLBACK Anvil::WindowWin3264::msg_callback_pfn_proc(HWND   window_handl
 void Anvil::WindowWin3264::run()
 {
     int done   = 0;
-    int result = 0;
+    //int result = 0;
 
     /* Run the message loop */
     while (!done)
@@ -215,7 +215,7 @@ void Anvil::WindowWin3264::run()
         if (msg.message == WM_QUIT)
         {
             done   = 1;
-            result = (int) msg.wParam;
+            //result = (int) msg.wParam;
         }
         else
         {


### PR DESCRIPTION
This fixes the indentation in miniz.cpp, a missing cstdio include and many incorrect _WIN32 checks.
Please note that "make install" still doesn't seem to work properly.