### PR TITLE
Updated Windows library directories for SDK v1.0.42

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,14 @@ if (WIN32)
     
     if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
             link_directories   ($ENV{VK_SDK_PATH}/Bin
-                                $ENV{VULKAN_SDK}/Bin)
+                                $ENV{VULKAN_SDK}/Bin
+				$ENV{VK_SDK_PATH}/Lib
+                                $ENV{VULKAN_SDK}/Lib)
     else()
             link_directories   ($ENV{VK_SDK_PATH}/Bin32
-                                $ENV{VULKAN_SDK}/Bin32)
+                                $ENV{VULKAN_SDK}/Bin32
+				$ENV{VK_SDK_PATH}/Lib32
+                                $ENV{VULKAN_SDK}/Lib32)
     endif()
 else()
     include_directories($ENV{VK_SDK_PATH}/x86_64/include

--- a/examples/DynamicBuffers/CMakeLists.txt
+++ b/examples/DynamicBuffers/CMakeLists.txt
@@ -29,10 +29,14 @@ if (WIN32)
     
     if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
             link_directories   ($ENV{VK_SDK_PATH}/Bin
-                                $ENV{VULKAN_SDK}/Bin)
+                                $ENV{VULKAN_SDK}/Bin
+				$ENV{VK_SDK_PATH}/Lib
+                                $ENV{VULKAN_SDK}/Lib)
     else()
             link_directories   ($ENV{VK_SDK_PATH}/Bin32
-                                $ENV{VULKAN_SDK}/Bin32)
+                                $ENV{VULKAN_SDK}/Bin32
+				$ENV{VK_SDK_PATH}/Lib32
+                                $ENV{VULKAN_SDK}/Lib32)
     endif()
 else()
     include_directories($ENV{VK_SDK_PATH}/x86_64/include

--- a/examples/MultiViewport/CMakeLists.txt
+++ b/examples/MultiViewport/CMakeLists.txt
@@ -29,10 +29,14 @@ if (WIN32)
     
     if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
             link_directories   ($ENV{VK_SDK_PATH}/Bin
-                                $ENV{VULKAN_SDK}/Bin)
+                                $ENV{VULKAN_SDK}/Bin
+				$ENV{VK_SDK_PATH}/Lib
+                                $ENV{VULKAN_SDK}/Lib)
     else()
             link_directories   ($ENV{VK_SDK_PATH}/Bin32
-                                $ENV{VULKAN_SDK}/Bin32)
+                                $ENV{VULKAN_SDK}/Bin32
+				$ENV{VK_SDK_PATH}/Lib32
+                                $ENV{VULKAN_SDK}/Lib32)
     endif()
 else()
     include_directories($ENV{VK_SDK_PATH}/x86_64/include

--- a/examples/OcclusionQuery/CMakeLists.txt
+++ b/examples/OcclusionQuery/CMakeLists.txt
@@ -29,10 +29,14 @@ if (WIN32)
     
     if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
             link_directories   ($ENV{VK_SDK_PATH}/Bin
-                                $ENV{VULKAN_SDK}/Bin)
+                                $ENV{VULKAN_SDK}/Bin
+				$ENV{VK_SDK_PATH}/Lib
+                                $ENV{VULKAN_SDK}/Lib)
     else()
             link_directories   ($ENV{VK_SDK_PATH}/Bin32
-                                $ENV{VULKAN_SDK}/Bin32)
+                                $ENV{VULKAN_SDK}/Bin32
+				$ENV{VK_SDK_PATH}/Lib32
+                                $ENV{VULKAN_SDK}/Lib32)
     endif()
 else()
     include_directories($ENV{VK_SDK_PATH}/x86_64/include

--- a/examples/OutOfOrderRasterization/CMakeLists.txt
+++ b/examples/OutOfOrderRasterization/CMakeLists.txt
@@ -29,10 +29,14 @@ if (WIN32)
     
     if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
             link_directories   ($ENV{VK_SDK_PATH}/Bin
-                                $ENV{VULKAN_SDK}/Bin)
+                                $ENV{VULKAN_SDK}/Bin
+				$ENV{VK_SDK_PATH}/Lib
+                                $ENV{VULKAN_SDK}/Lib)
     else()
             link_directories   ($ENV{VK_SDK_PATH}/Bin32
-                                $ENV{VULKAN_SDK}/Bin32)
+                                $ENV{VULKAN_SDK}/Bin32
+				$ENV{VK_SDK_PATH}/Lib32
+                                $ENV{VULKAN_SDK}/Lib32)
     endif()
 else()
     include_directories($ENV{VK_SDK_PATH}/x86_64/include

--- a/examples/PushConstants/CMakeLists.txt
+++ b/examples/PushConstants/CMakeLists.txt
@@ -29,10 +29,14 @@ if (WIN32)
     
     if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
             link_directories   ($ENV{VK_SDK_PATH}/Bin
-                                $ENV{VULKAN_SDK}/Bin)
+                                $ENV{VULKAN_SDK}/Bin
+				$ENV{VK_SDK_PATH}/Lib
+                                $ENV{VULKAN_SDK}/Lib)
     else()
             link_directories   ($ENV{VK_SDK_PATH}/Bin32
-                                $ENV{VULKAN_SDK}/Bin32)
+                                $ENV{VULKAN_SDK}/Bin32
+				$ENV{VK_SDK_PATH}/Lib32
+                                $ENV{VULKAN_SDK}/Lib32)
     endif()
 else()
     include_directories($ENV{VK_SDK_PATH}/x86_64/include


### PR DESCRIPTION
In the [Vulkan SDK version 1.0.42](https://vulkan.lunarg.com/doc/sdk/1.0.42.2/windows/release_notes-1.0.html) for Windows, libraries have moved from `Bin` and `Bin32` to `Lib` and `Lib32`. This commit updates the affected CMakefiles. The old directories are kept for backwards compatibility.