### PR TITLE
GraphicsPipelineInfo::get_n_vertex_attribute_properties

### DIFF
--- a/include/misc/graphics_pipeline_info.h
+++ b/include/misc/graphics_pipeline_info.h
@@ -376,6 +376,9 @@ namespace Anvil
 
         /** Tells the number of patch control points associated with this instance. **/
         uint32_t get_n_patch_control_points() const;
+        
+        /** Tells the number of vertex attributes (as specified by the owner) associated with this instance. **/
+        uint32_t get_n_vertex_attribute_properties() const;
 
         /** Returns properties of a vertex attribute at a given index. These properties are as specified by the owner.
          *

--- a/src/misc/graphics_pipeline_info.cpp
+++ b/src/misc/graphics_pipeline_info.cpp
@@ -735,6 +735,11 @@ uint32_t Anvil::GraphicsPipelineInfo::get_n_patch_control_points() const
     return m_n_patch_control_points;
 }
 
+uint32_t Anvil::GraphicsPipelineInfo::get_n_vertex_attribute_properties() const
+{
+    return m_attributes.size();
+}
+
 bool Anvil::GraphicsPipelineInfo::get_vertex_attribute_properties(uint32_t           in_n_vertex_input_attribute,
                                                                   uint32_t*          out_opt_location_ptr,
                                                                   VkFormat*          out_opt_format_ptr,


### PR DESCRIPTION
You can retrieve vertex attribute properties using **GraphicsPipelineInfo::get_vertex_attribute_properties**, but you need to provide an index, and there's no way to retrieve the number of available vertex attributes right now.