### PR TITLE
Bug-fixes & improvements:

### DIFF
--- a/examples/DynamicBuffers/CMakeLists.txt
+++ b/examples/DynamicBuffers/CMakeLists.txt
@@ -18,6 +18,8 @@ endif()
 
 add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
 
+target_include_directories(Anvil PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/anvil/include")
+
 include_directories(${Anvil_SOURCE_DIR}/include
                     ${DynamicBuffers_SOURCE_DIR}/include)
 

--- a/examples/MultiViewport/CMakeLists.txt
+++ b/examples/MultiViewport/CMakeLists.txt
@@ -18,6 +18,8 @@ endif()
 
 add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
 
+target_include_directories(Anvil PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/anvil/include")
+
 include_directories(${Anvil_SOURCE_DIR}/include
                     ${MultiViewport_SOURCE_DIR}/include)
 

--- a/examples/OcclusionQuery/CMakeLists.txt
+++ b/examples/OcclusionQuery/CMakeLists.txt
@@ -18,6 +18,8 @@ endif()
 
 add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
 
+target_include_directories(Anvil PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/anvil/include")
+
 include_directories(${Anvil_SOURCE_DIR}/include
                     ${OcclusionQuery_SOURCE_DIR}/include)
 

--- a/examples/OutOfOrderRasterization/CMakeLists.txt
+++ b/examples/OutOfOrderRasterization/CMakeLists.txt
@@ -18,6 +18,8 @@ endif()
 
 add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
 
+target_include_directories(Anvil PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/anvil/include")
+
 include_directories(${Anvil_SOURCE_DIR}/include
                     ${OutOfOrderRasterization_SOURCE_DIR}/include)
 

--- a/examples/PushConstants/CMakeLists.txt
+++ b/examples/PushConstants/CMakeLists.txt
@@ -18,6 +18,8 @@ endif()
 
 add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
 
+target_include_directories(Anvil PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/anvil/include")
+
 include_directories(${Anvil_SOURCE_DIR}/include
                     ${PushConstants_SOURCE_DIR}/include)
 

--- a/include/misc/render_pass_info.h
+++ b/include/misc/render_pass_info.h
@@ -544,42 +544,42 @@ namespace Anvil
         /* Holds properties of a sub-pass attachment */
         typedef struct SubPassAttachment
         {
-            RenderPassAttachment* attachment_ptr;
-            uint32_t              highest_subpass_index;
-            VkImageLayout         layout;
-            uint32_t              lowest_subpass_index;
-            RenderPassAttachment* resolve_attachment_ptr;
+            uint32_t      attachment_index;
+            uint32_t      highest_subpass_index;
+            VkImageLayout layout;
+            uint32_t      lowest_subpass_index;
+            uint32_t      resolve_attachment_index;
 
             /* Dummy constructor. Should only be used by STL containers */
             SubPassAttachment()
             {
-                attachment_ptr         = nullptr;
-                highest_subpass_index  = UINT32_MAX;
-                layout                 = VK_IMAGE_LAYOUT_MAX_ENUM;
-                lowest_subpass_index   = UINT32_MAX;
-                resolve_attachment_ptr = nullptr;
+                attachment_index         = UINT32_MAX;
+                highest_subpass_index    = UINT32_MAX;
+                layout                   = VK_IMAGE_LAYOUT_MAX_ENUM;
+                lowest_subpass_index     = UINT32_MAX;
+                resolve_attachment_index = UINT32_MAX;
             }
 
             /** Constructor.
              *
-             *  @param in_attachment_ptr         Render-pass attachment that this sub-pass attachment should reference.
-             *                                   Must not be nullptr.
-             *  @param in_layout                 Layout to use for the attachment when executing the subpass.
-             *                                   Driver takes care of transforming the attachment to the requested layout
-             *                                   before subpass commands starts executing.
-             *  @param in_resolve_attachment_ptr If not nullptr, this should point to the render-pass attachment, to which
-             *                                   MS data of @param in_attachment_ptr should be resolved. If nullptr, it is
-             *                                   assumed the sub-pass should not resolve the MS data.
+             *  @param in_attachment_index             Index of render-pass attachment that this sub-pass attachment should reference.
+             *                                         Must not be UINT32_MAX.
+             *  @param in_layout                       Layout to use for the attachment when executing the subpass.
+             *                                         Driver takes care of transforming the attachment to the requested layout
+             *                                         before subpass commands starts executing.
+             *  @param in_opt_resolve_attachment_index If not UINT32_MAX, this should point to the render-pass attachment, to which
+             *                                         MS data of @param in_attachment_ptr should be resolved. If UINT32_MAX, it is
+             *                                         assumed the sub-pass should not resolve the MS data.
              **/
-            SubPassAttachment(RenderPassAttachment* in_attachment_ptr,
-                              VkImageLayout         in_layout,
-                              RenderPassAttachment* in_opt_resolve_attachment_ptr)
+            SubPassAttachment(const uint32_t& in_attachment_index,
+                              VkImageLayout   in_layout,
+                              const uint32_t& in_opt_resolve_attachment_index)
             {
-                attachment_ptr         = in_attachment_ptr;
-                highest_subpass_index  = UINT32_MAX;
-                layout                 = in_layout;
-                lowest_subpass_index   = UINT32_MAX;
-                resolve_attachment_ptr = in_opt_resolve_attachment_ptr;
+                attachment_index         = in_attachment_index;
+                highest_subpass_index    = UINT32_MAX;
+                layout                   = in_layout;
+                lowest_subpass_index     = UINT32_MAX;
+                resolve_attachment_index = in_opt_resolve_attachment_index;
             }
         } SubPassAttachment;
 

--- a/include/misc/types.h
+++ b/include/misc/types.h
@@ -1323,6 +1323,8 @@ namespace Anvil
 
         KHR16BitStorageFeatures(const VkPhysicalDevice16BitStorageFeaturesKHR& in_features);
 
+        VkPhysicalDevice16BitStorageFeaturesKHR get_vk_physical_device_16_bit_storage_features() const;
+
         bool operator==(const KHR16BitStorageFeatures& in_features) const;
     } KHR16BitStorageFeatures;
 

--- a/include/wrappers/descriptor_set.h
+++ b/include/wrappers/descriptor_set.h
@@ -689,9 +689,12 @@ namespace Anvil
                                      current_element_index < last_element_index;
                                    ++current_element_index)
             {
-                m_dirty |= !(binding_items[current_element_index] == in_elements_ptr[current_element_index - in_element_range.first]);
+                if (!(binding_items[current_element_index] == in_elements_ptr[current_element_index - in_element_range.first]) )
+                {
+                    m_dirty = true;
 
-                binding_items[current_element_index] = in_elements_ptr[current_element_index - in_element_range.first];
+                    binding_items[current_element_index] = in_elements_ptr[current_element_index - in_element_range.first];
+                }
             }
 
             return true;
@@ -882,13 +885,13 @@ namespace Anvil
         bool update_using_template_method  () const;
 
         /* Private variables */
-        BindingIndexToBindingItemsMap     m_bindings;
-        VkDescriptorSet                   m_descriptor_set;
-        const Anvil::BaseDevice*          m_device_ptr;
-        mutable bool                      m_dirty;
-        const Anvil::DescriptorSetLayout* m_layout_ptr;
-        Anvil::DescriptorPool*            m_parent_pool_ptr;
-        bool                              m_unusable;
+        mutable BindingIndexToBindingItemsMap m_bindings;
+        VkDescriptorSet                       m_descriptor_set;
+        const Anvil::BaseDevice*              m_device_ptr;
+        mutable bool                          m_dirty;
+        const Anvil::DescriptorSetLayout*     m_layout_ptr;
+        Anvil::DescriptorPool*                m_parent_pool_ptr;
+        bool                                  m_unusable;
 
         mutable std::vector<VkDescriptorBufferInfo> m_cached_ds_info_buffer_info_items_vk;
         mutable std::vector<VkDescriptorImageInfo>  m_cached_ds_info_image_info_items_vk;

--- a/include/wrappers/device.h
+++ b/include/wrappers/device.h
@@ -33,6 +33,7 @@
 
 #include "misc/debug.h"
 #include "misc/mt_safety.h"
+#include "misc/struct_chainer.h"
 #include "misc/types.h"
 #include <algorithm>
 
@@ -664,6 +665,9 @@ namespace Anvil
         } DeviceQueueFamilyInfo;
 
         /* Protected functions */
+
+        std::unique_ptr<Anvil::StructChain<VkPhysicalDeviceFeatures2KHR > > get_physical_device_features_chain() const;
+
         std::vector<float> get_queue_priorities(const QueueFamilyInfo*              in_queue_family_info_ptr) const;
         void               init                (const DeviceExtensionConfiguration& in_extensions,
                                                 const std::vector<std::string>&     in_layers,

--- a/src/misc/types.cpp
+++ b/src/misc/types.cpp
@@ -384,6 +384,21 @@ bool Anvil::KHR16BitStorageFeatures::operator==(const KHR16BitStorageFeatures& i
             in_features.is_uniform_and_storage_buffer_16_bit_access_supported == is_uniform_and_storage_buffer_16_bit_access_supported);
 }
 
+VkPhysicalDevice16BitStorageFeaturesKHR Anvil::KHR16BitStorageFeatures::get_vk_physical_device_16_bit_storage_features() const
+{
+    VkPhysicalDevice16BitStorageFeaturesKHR result;
+
+    result.pNext                              = nullptr;
+    result.storageBuffer16BitAccess           = BOOL_TO_VK_BOOL32(is_storage_buffer_16_bit_access_supported);
+    result.storageInputOutput16               = BOOL_TO_VK_BOOL32(is_input_output_storage_supported);
+    result.storagePushConstant16              = BOOL_TO_VK_BOOL32(is_push_constant_16_bit_storage_supported);
+    result.sType                              = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES_KHR;
+    result.uniformAndStorageBuffer16BitAccess = BOOL_TO_VK_BOOL32(is_uniform_and_storage_buffer_16_bit_access_supported);
+
+    return result;
+
+}
+
 Anvil::KHRMaintenance3Properties::KHRMaintenance3Properties()
     :max_memory_allocation_size(std::numeric_limits<VkDeviceSize>::max() ),
      max_per_set_descriptors   (UINT32_MAX)

--- a/src/wrappers/descriptor_set_group.cpp
+++ b/src/wrappers/descriptor_set_group.cpp
@@ -111,7 +111,6 @@ Anvil::DescriptorSetGroup::DescriptorSetGroup(const DescriptorSetGroup* in_paren
 {
     auto descriptor_set_layout_manager_ptr = m_device_ptr->get_descriptor_set_layout_manager();
 
-    anvil_assert(  in_parent_dsg_ptr                                                                                                        != nullptr);
     anvil_assert(  in_parent_dsg_ptr->m_parent_dsg_ptr                                                                                      == nullptr);
     anvil_assert(((in_parent_dsg_ptr->m_descriptor_pool_ptr->get_flags() & Anvil::DESCRIPTOR_POOL_FLAG_CREATE_FREE_DESCRIPTOR_SET_BIT) > 0) == in_releaseable_sets);
 
@@ -125,7 +124,7 @@ Anvil::DescriptorSetGroup::DescriptorSetGroup(const DescriptorSetGroup* in_paren
     /* Initialize descriptor pool */
     m_descriptor_pool_ptr = Anvil::DescriptorPool::create(in_parent_dsg_ptr->m_device_ptr,
                                                           in_parent_dsg_ptr->m_descriptor_pool_ptr->get_n_maximum_sets(),
-                                                          in_releaseable_sets,
+                                                          in_parent_dsg_ptr->m_descriptor_pool_ptr->get_flags         (),
                                                           m_pool_size_per_descriptor_type,
                                                           Anvil::Utils::convert_boolean_to_mt_safety_enum(is_mt_safe() ));
 
@@ -216,11 +215,11 @@ bool Anvil::DescriptorSetGroup::bake_descriptor_pool()
             VkDescriptorType ds_binding_type;
 
             current_ds_layout_info_ptr->get_binding_properties_by_index_number(n_ds_binding,
-                                                                               nullptr, /* out_opt_binding_index_ptr               */
+                                                                               nullptr, /* out_opt_binding_index_Ptr */
                                                                               &ds_binding_type,
                                                                               &ds_binding_array_size,
                                                                                nullptr,  /* out_opt_stage_flags_ptr                */
-                                                                               nullptr);/* out_opt_immutable_samplers_enabled_ptr */
+                                                                               nullptr); /* out_opt_immutable_samplers_enabled_ptr */
 
             if (ds_binding_type > VK_DESCRIPTOR_TYPE_END_RANGE)
             {

--- a/src/wrappers/physical_device.cpp
+++ b/src/wrappers/physical_device.cpp
@@ -77,7 +77,7 @@ bool Anvil::PhysicalDevice::init()
     uint32_t                                               n_physical_device_queues        = 0;
     bool                                                   result                          = true;
     VkResult                                               result_vk                       = VK_ERROR_INITIALIZATION_FAILED;
-    const bool                                             texture_gather_bias_lod_support = is_device_extension_supported(VK_AMD_TEXTURE_GATHER_BIAS_LOD_EXTENSION_NAME);
+    bool                                                   texture_gather_bias_lod_support = false;
 
     anvil_assert(m_physical_device != VK_NULL_HANDLE);
 
@@ -187,6 +187,8 @@ bool Anvil::PhysicalDevice::init()
     }
 
     /* Retrieve device format properties */
+    texture_gather_bias_lod_support = is_device_extension_supported(VK_AMD_TEXTURE_GATHER_BIAS_LOD_EXTENSION_NAME);;
+
     for (VkFormat current_format = static_cast<VkFormat>(1); /* skip the _UNDEFINED format */
                   current_format < VK_FORMAT_RANGE_SIZE;
                   current_format = static_cast<VkFormat>(current_format + 1))

--- a/src/wrappers/render_pass.cpp
+++ b/src/wrappers/render_pass.cpp
@@ -198,7 +198,7 @@ bool Anvil::RenderPass::init()
                   subpass_color_attachment_iterator != (*subpass_iterator)->color_attachments_map.cend();
                 ++subpass_color_attachment_iterator)
         {
-            if (subpass_color_attachment_iterator->second.resolve_attachment_ptr != nullptr)
+            if (subpass_color_attachment_iterator->second.resolve_attachment_index != UINT32_MAX)
             {
                 need_color_resolve_attachments = true;
 
@@ -265,7 +265,7 @@ bool Anvil::RenderPass::init()
 
             if (need_color_resolve_attachments)
             {
-                if (subpass_color_attachment_iterator->second.resolve_attachment_ptr != nullptr)
+                if (subpass_color_attachment_iterator->second.resolve_attachment_index != UINT32_MAX)
                 {
                     current_subpass_attachment_set_ptr->resolve_color_attachments_vk[subpass_color_attachment_iterator->first] = m_render_pass_info_ptr->get_attachment_reference_for_resolve_attachment(subpass_iterator,
                                                                                                                                                                                                          subpass_color_attachment_iterator);
@@ -273,7 +273,7 @@ bool Anvil::RenderPass::init()
             }
         }
 
-        if ((*subpass_iterator)->depth_stencil_attachment.attachment_ptr != nullptr)
+        if ((*subpass_iterator)->depth_stencil_attachment.attachment_index != UINT32_MAX)
         {
             current_subpass_attachment_set_ptr->depth_attachment_vk = m_render_pass_info_ptr->get_attachment_reference_from_subpass_attachment((*subpass_iterator)->depth_stencil_attachment);
         }
@@ -294,7 +294,9 @@ bool Anvil::RenderPass::init()
                   subpass_preserve_attachment_iterator != (*subpass_iterator)->preserved_attachments.cend();
                 ++subpass_preserve_attachment_iterator)
         {
-            current_subpass_attachment_set_ptr->preserve_attachments_vk.push_back(subpass_preserve_attachment_iterator->attachment_ptr->index);
+            current_subpass_attachment_set_ptr->preserve_attachments_vk.push_back(
+                m_render_pass_info_ptr->m_attachments.at(subpass_preserve_attachment_iterator->attachment_index).index
+            );
         }
 
         /* Prepare the VK subpass descriptor */
@@ -307,12 +309,12 @@ bool Anvil::RenderPass::init()
         subpass_vk.colorAttachmentCount              = n_color_attachments;
         subpass_vk.flags                             = 0;
         subpass_vk.inputAttachmentCount              = n_input_attachments;
-        subpass_vk.pColorAttachments                 = (n_color_attachments > 0)                                                 ? &current_subpass_attachment_set_ptr->color_attachments_vk.at(0)
-                                                                                                                                 : nullptr;
-        subpass_vk.pDepthStencilAttachment           = ((*subpass_iterator)->depth_stencil_attachment.attachment_ptr != nullptr) ? &current_subpass_attachment_set_ptr->depth_attachment_vk
-                                                                                                                                 : nullptr;
-        subpass_vk.pInputAttachments                 = (n_input_attachments > 0)                                                 ? &current_subpass_attachment_set_ptr->input_attachments_vk.at(0)
-                                                                                                                                 : nullptr;
+        subpass_vk.pColorAttachments                 = (n_color_attachments > 0)                                                      ? &current_subpass_attachment_set_ptr->color_attachments_vk.at(0)
+                                                                                                                                      : nullptr;
+        subpass_vk.pDepthStencilAttachment           = ((*subpass_iterator)->depth_stencil_attachment.attachment_index != UINT32_MAX) ? &current_subpass_attachment_set_ptr->depth_attachment_vk
+                                                                                                                                      : nullptr;
+        subpass_vk.pInputAttachments                 = (n_input_attachments > 0)                                                      ? &current_subpass_attachment_set_ptr->input_attachments_vk.at(0)
+                                                                                                                                      : nullptr;
         subpass_vk.pipelineBindPoint                 = VK_PIPELINE_BIND_POINT_GRAPHICS;
         subpass_vk.pPreserveAttachments              = (n_preserved_attachments > 0) ? &current_subpass_attachment_set_ptr->preserve_attachments_vk.at(0)
                                                                                      : nullptr;

--- a/src/wrappers/swapchain.cpp
+++ b/src/wrappers/swapchain.cpp
@@ -245,20 +245,20 @@ void Anvil::Swapchain::destroy_swapchain()
     /* If this assertion failure explodes, your application attempted to release a swapchain without presenting all acquired swapchain images.
      * That's illegal per Vulkan spec.
      */
-    if (m_swapchain != VK_NULL_HANDLE)
+    lock();
     {
-        anvil_assert(m_n_acquire_counter == m_n_present_counter);
-
-        lock();
+        if (m_swapchain != VK_NULL_HANDLE)
         {
+            anvil_assert(m_n_acquire_counter == m_n_present_counter);
+
             m_khr_swapchain_entrypoints.vkDestroySwapchainKHR(m_device_ptr->get_device_vk(),
                                                               m_swapchain,
                                                               nullptr /* pAllocator */);
         }
-        unlock();
 
         m_swapchain = VK_NULL_HANDLE;
     }
+    unlock();
 }
 
 /** Please see header for specification */


### PR DESCRIPTION
* #62: Exception when trying to bake a descriptor set with null bindings
* Descriptor set write support can now handle arrayed bindings with gaps.
* Fix an issue where RenderPassInfo would use obsolete pointers under certain
  circumstances.
* Fix an issue where bindings would not be marked as clean at update time
* Fix broken sampler descriptor support.
* Fix VK_AMD_texture_gather_bias_lod support regression