### PR TITLE
Fix build without glslang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,6 @@ SET (SRC_LIST "${Anvil_SOURCE_DIR}/include/misc/memalloc_backends/backend_onesho
               "${Anvil_SOURCE_DIR}/include/misc/formats.h"
               "${Anvil_SOURCE_DIR}/include/misc/fp16.h"
               "${Anvil_SOURCE_DIR}/include/misc/framebuffer_create_info.h"
-              "${Anvil_SOURCE_DIR}/include/misc/glsl_to_spirv.h"
               "${Anvil_SOURCE_DIR}/include/misc/graphics_pipeline_create_info.h"
               "${Anvil_SOURCE_DIR}/include/misc/image_create_info.h"
               "${Anvil_SOURCE_DIR}/include/misc/image_view_create_info.h"
@@ -128,7 +127,6 @@ SET (SRC_LIST "${Anvil_SOURCE_DIR}/include/misc/memalloc_backends/backend_onesho
               "${Anvil_SOURCE_DIR}/src/misc/formats.cpp"
               "${Anvil_SOURCE_DIR}/src/misc/fp16.cpp"
               "${Anvil_SOURCE_DIR}/src/misc/framebuffer_create_info.cpp"
-              "${Anvil_SOURCE_DIR}/src/misc/glsl_to_spirv.cpp"
               "${Anvil_SOURCE_DIR}/src/misc/graphics_pipeline_create_info.cpp"
               "${Anvil_SOURCE_DIR}/src/misc/image_create_info.cpp"
               "${Anvil_SOURCE_DIR}/src/misc/image_view_create_info.cpp"
@@ -187,6 +185,12 @@ SET (SRC_LIST "${Anvil_SOURCE_DIR}/include/misc/memalloc_backends/backend_onesho
               "${Anvil_SOURCE_DIR}/deps/VulkanMemoryAllocator/vk_mem_alloc.h"
                          )
 
+if (ANVIL_LINK_WITH_GLSLANG)
+    list(APPEND SRC_LIST
+        "${Anvil_SOURCE_DIR}/include/misc/glsl_to_spirv.h"
+        "${Anvil_SOURCE_DIR}/src/misc/glsl_to_spirv.cpp")
+endif()
+
 # prepare source code files for different OS
 if(WIN32)
     if (ANVIL_INCLUDE_WIN3264_WINDOW_SYSTEM_SUPPORT)
@@ -225,11 +229,13 @@ else()
     set(CMAKE_CXX_FLAGS "$(CMAKE_CXX_FLAGS) /EHsc /MP")
 endif()
 
-# Add dependendencies
-if (WIN32)
-    add_subdirectory("deps\\glslang")
-else()
-    add_subdirectory("deps/glslang")
+if (ANVIL_LINK_WITH_GLSLANG)
+    # Add dependendencies
+    if (WIN32)
+        add_subdirectory("deps\\glslang")
+    else()
+        add_subdirectory("deps/glslang")
+    endif()
 endif()
 
 # Enable level-4 warnings

--- a/include/wrappers/shader_module.h
+++ b/include/wrappers/shader_module.h
@@ -146,6 +146,7 @@ namespace Anvil
             return m_cs_entrypoint_name;
         }
 
+#ifdef ANVIL_LINK_WITH_GLSLANG
         /** Returns a disassembly of the SPIR-V blob.
          *
          *  The actual disassembly is retrieved from glslang and cached for subsequent requests.
@@ -153,6 +154,7 @@ namespace Anvil
          *  This function only returns a non-empty string if ANVIL_LINK_WITH_GLSLANG is enabled.
          */
         const std::string& get_disassembly();
+#endif
 
         /** Returns name of the fragment shader stage entry-point, as defined at construction time.
          *

--- a/src/wrappers/shader_module.cpp
+++ b/src/wrappers/shader_module.cpp
@@ -287,10 +287,10 @@ void Anvil::ShaderModule::destroy()
     }
 }
 
+#ifdef ANVIL_LINK_WITH_GLSLANG
 /** Please see header for specification */
 const std::string& Anvil::ShaderModule::get_disassembly()
 {
-    #ifdef ANVIL_LINK_WITH_GLSLANG
     {
         if (m_disassembly.size() == 0)
         {
@@ -303,10 +303,10 @@ const std::string& Anvil::ShaderModule::get_disassembly()
             m_disassembly = disassembly_sstream.str();
         }
     }
-    #endif
 
     return m_disassembly;
 }
+#endif
 
 /** Please see header for specification */
 bool Anvil::ShaderModule::init_from_spirv_blob(const char* in_spirv_blob,


### PR DESCRIPTION
While building Anvil without GLSLANG, we get a compilation error.
This commit fixes this compilation error by not defining the
get_disassembly function in the ShaderModule class, which
was trying to return the m_disassembly variable (which is also
not defined in this case). Also the commit removes dependencies on
the GLSLANG headers in this case.