### PR TITLE
Fixed the quatifier and label problem assocated with bake_spirv_by_sw…

### DIFF
--- a/include/misc/glsl_to_spirv.h
+++ b/include/misc/glsl_to_spirv.h
@@ -332,7 +332,7 @@ namespace Anvil
             EShLanguage get_glslang_shader_stage          () const;
         #else
             bool bake_spirv_blob_by_spawning_glslang_process(const std::string& in_glsl_filename_with_path,
-                                                             const std::string& in_spirv_filename_with_path);
+                                                             const std::string& in_spirv_filename_with_path) const;
         #endif
 
         /* Private members */

--- a/src/misc/glsl_to_spirv.cpp
+++ b/src/misc/glsl_to_spirv.cpp
@@ -561,6 +561,8 @@ bool Anvil::GLSLShaderToSPIRVGenerator::bake_spirv_blob() const
     }
     #endif
 
+    end:
+    
     return result;
 }
 
@@ -722,12 +724,13 @@ bool Anvil::GLSLShaderToSPIRVGenerator::bake_spirv_blob() const
      *  @return true if successful, false otherwise.
      **/
     bool Anvil::GLSLShaderToSPIRVGenerator::bake_spirv_blob_by_spawning_glslang_process(const std::string& in_glsl_filename_with_path,
-                                                                                        const std::string& in_spirv_filename_with_path)
+                                                                                        const std::string& in_spirv_filename_with_path) const
     {
         auto        callback_arg            = OnGLSLToSPIRVConversionAboutToBeStartedCallbackArgument(this);
         std::string glslangvalidator_params;
         bool        result                  = false;
         size_t      spirv_file_size         = 0;
+        char*       spirv_blob_ptr          = nullptr;
 
         callback(GLSL_SHADER_TO_SPIRV_GENERATOR_CALLBACK_ID_CONVERSION_ABOUT_TO_START,
                 &callback_arg);
@@ -818,7 +821,7 @@ bool Anvil::GLSLShaderToSPIRVGenerator::bake_spirv_blob() const
         #endif
 
         /* Now, read the SPIR-V file contents */
-        char* spirv_blob_ptr = nullptr;
+        
 
         Anvil::IO::read_file(in_spirv_filename_with_path.c_str(),
                              false, /* is_text_file */

--- a/src/misc/glsl_to_spirv.cpp
+++ b/src/misc/glsl_to_spirv.cpp
@@ -553,15 +553,18 @@ bool Anvil::GLSLShaderToSPIRVGenerator::bake_spirv_blob() const
             result = bake_spirv_blob_by_calling_glslang(m_glsl_source_code.c_str() );
         }
     }
+
     #else
     {
         /* We need to point glslangvalidator at a location where it can stash the SPIR-V blob. */
         result = bake_spirv_blob_by_spawning_glslang_process(glsl_filename_with_path,
                                                              "temp.spv");
     }
+
+end:
     #endif
 
-    end:
+
     
     return result;
 }


### PR DESCRIPTION
When `bake_spirv_blob_by_spawning_glslang_process `method was split from `get_spirv_blob` the const quantifier was not added to bake_spirv_blob_by_spawning_glslang_process. The split also caused an error with the gotos in `get_spirv_blob` because of the missing end label.