### PR TITLE
Bug-fixes

### DIFF
--- a/include/misc/buffer_create_info.h
+++ b/include/misc/buffer_create_info.h
@@ -212,6 +212,15 @@ namespace Anvil
             return m_usage_flags;
         }
 
+        /** Use to specify contents which should be uploaded to a buffer at memory block assignment time.
+         *
+         *  Note that this setting will be ignored for partially-resident buffers.
+         *
+         *  The specified pointer must remain valid until Buffer::set_nonsparse_memory() call time.
+         *
+         *  @param in_client_data_ptr Pointer to data storage holding contents the created buffer should be filled with.
+         *                            Must remain valid until memory block assignment time.
+         */
         void set_client_data(const void* const in_client_data_ptr)
         {
             m_client_data_ptr = in_client_data_ptr;

--- a/include/misc/render_pass_create_info.h
+++ b/include/misc/render_pass_create_info.h
@@ -377,6 +377,16 @@ namespace Anvil
             return m_device_ptr;
         }
 
+        /* Returns the largest location assigned to color attachments for the specified subpass.
+         *
+         * If no color attachments have been defined for the queried subpass, UINT32_MAX is returned.
+         *
+         * @param in_subpass_id ID of the subpass to use for the query.
+         *
+         * @return As per description.
+         **/
+        uint32_t get_max_color_location_used_by_subpass(const SubPassID& in_subpass_id) const;
+
         /** Returns the number of added attachments */
         uint32_t get_n_attachments() const
         {

--- a/include/misc/types_struct.h
+++ b/include/misc/types_struct.h
@@ -731,6 +731,8 @@ namespace Anvil
            return &image_barrier_vk;
        }
 
+       bool operator==(const ImageBarrier& in_barrier) const;
+
     private:
         ImageBarrier& operator=(const ImageBarrier&);
     } ImageBarrier;

--- a/include/wrappers/command_buffer.h
+++ b/include/wrappers/command_buffer.h
@@ -481,7 +481,7 @@ namespace Anvil
          *  Calling this function for a command buffer which has not been put into a recording mode
          *  (by issuing a start_recording() call earlier) will result in an assertion failure.
          *
-         *  It is also illegal to call this function when not recording renderpass commands. Doing so
+         *  It is also illegal to call this function when recording renderpass commands. Doing so
          *  will also result in an assertion failure.
          *
          *  Any Vulkan object wrapper instances passed to this function are going to be retained,

--- a/src/misc/types_struct.cpp
+++ b/src/misc/types_struct.cpp
@@ -745,6 +745,7 @@ Anvil::ImageFormatProperties::ImageFormatProperties(const VkImageFormatPropertie
 /** Please see header for specification */
 Anvil::ImageBarrier::ImageBarrier(const ImageBarrier& in)
 {
+    by_region              = in.by_region;
     dst_access_mask        = in.dst_access_mask;
     dst_queue_family_index = in.dst_queue_family_index;
     image                  = in.image;
@@ -803,6 +804,30 @@ Anvil::ImageBarrier::ImageBarrier(VkAccessFlags           in_source_access_mask,
 Anvil::ImageBarrier::~ImageBarrier()
 {
     /* Stub */
+}
+
+bool Anvil::ImageBarrier::operator==(const ImageBarrier& in_barrier) const
+{
+    bool result = true;
+
+    result &= (dst_access_mask == in_barrier.dst_access_mask);
+    result &= (src_access_mask == in_barrier.src_access_mask);
+
+    result &= (by_region              == in_barrier.by_region);
+    result &= (dst_queue_family_index == in_barrier.dst_queue_family_index);
+    result &= (image                  == in_barrier.image);
+    result &= (image_ptr              == in_barrier.image_ptr);
+    result &= (new_layout             == in_barrier.new_layout);
+    result &= (old_layout             == in_barrier.old_layout);
+    result &= (src_queue_family_index == in_barrier.src_queue_family_index);
+
+    result &= (subresource_range.aspectMask     == in_barrier.subresource_range.aspectMask);
+    result &= (subresource_range.baseArrayLayer == in_barrier.subresource_range.baseArrayLayer);
+    result &= (subresource_range.baseMipLevel   == in_barrier.subresource_range.baseMipLevel);
+    result &= (subresource_range.layerCount     == in_barrier.subresource_range.layerCount);
+    result &= (subresource_range.levelCount     == in_barrier.subresource_range.levelCount);
+
+    return result;
 }
 
 Anvil::KHR16BitStorageFeatures::KHR16BitStorageFeatures()

--- a/src/wrappers/pipeline_layout.cpp
+++ b/src/wrappers/pipeline_layout.cpp
@@ -74,7 +74,7 @@ bool Anvil::PipelineLayout::bake(const std::vector<DescriptorSetCreateInfoUnique
     /* Convert descriptor set layouts to Vulkan equivalents */
     const VkDescriptorSetLayout dummy_ds_layout = m_device_ptr->get_dummy_descriptor_set_layout()->get_layout();
 
-    ds_layouts_vk.resize(in_ds_create_info_items_ptr->size() + 1,
+    ds_layouts_vk.resize(in_ds_create_info_items_ptr->size(),
                          dummy_ds_layout);
 
     if (in_ds_create_info_items_ptr         != nullptr &&


### PR DESCRIPTION
Fix an issue where gfx pipeline create info structs would be malformed if not all attachments had image views bound.
Fix an issue where memory ranges would not be aligned to required boundaries at invalidation / flush time
#92: Data pointer parameter for Anvil::Buffer::create was removed
#93: Anvil::PipelineLayout::bake uses more descriptor sets than were originally specified
#94: Small error in description for CommandBufferBase::record_clear_color_image
