### PR TITLE
Access to glslang::TProgram::getInfoDebugLog

### DIFF
--- a/include/misc/glsl_to_spirv.h
+++ b/include/misc/glsl_to_spirv.h
@@ -243,6 +243,11 @@ namespace Anvil
              {
                  return m_program_info_log;
              }
+             
+             const std::string& get_program_debug_info_log() const
+             {
+                 return m_program_debug_info_log;
+             }
 
              /** Returns info log which contains detailed information regarding the shader compilation process.
               *
@@ -340,6 +345,7 @@ namespace Anvil
             mutable std::string            m_debug_info_log;
             std::unique_ptr<GLSLangLimits> m_limits_ptr;
             mutable std::string            m_program_info_log;
+            mutable std::string            m_program_debug_info_log;
             mutable std::string            m_shader_info_log;
         #endif
 

--- a/src/misc/glsl_to_spirv.cpp
+++ b/src/misc/glsl_to_spirv.cpp
@@ -632,6 +632,7 @@ end:
 
             link_result        = new_program_ptr->link      (EShMsgDefault);
             m_program_info_log = new_program_ptr->getInfoLog();
+			m_program_debug_info_log = new_program_ptr->getInfoDebugLog();
 
             if (!link_result)
             {


### PR DESCRIPTION
Anvil only provided access to _getInfoLog_, but not to _getInfoDebugLog_, which contains additional debug information.