### PR TITLE
Fix warnings and add option to build Script 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project (Anvil)
 option(ANVIL_INCLUDE_WIN3264_WINDOW_SYSTEM_SUPPORT "Includes 32-/64-bit Windows window system support (Windows builds only)" ON)
 option(ANVIL_INCLUDE_XCB_WINDOW_SYSTEM_SUPPORT     "Includes XCB window system support (Linux builds only)" ON)
 option(ANVIL_LINK_WITH_GLSLANG                     "Links with glslang, instead of spawning a new process whenever GLSL->SPIR-V conversion is required" ON)
+option(ANVIL_LINK_EXAMPLES                         "Build examples showing how to use Anvil" OFF)
 
 
 # Do not modify anything after this line, unless you know what you're doing.
@@ -236,6 +237,15 @@ if (ANVIL_LINK_WITH_GLSLANG)
     else()
         add_subdirectory("deps/glslang")
     endif()
+endif()
+
+
+if (ANVIL_LINK_EXAMPLES)
+	add_subdirectory("examples/DynamicBuffers")
+	add_subdirectory("examples/MultiViewport")
+	add_subdirectory("examples/OcclusionQuery")
+	add_subdirectory("examples/OutOfOrderRasterization")
+	add_subdirectory("examples/PushConstants")
 endif()
 
 # Enable level-4 warnings

--- a/examples/DynamicBuffers/CMakeLists.txt
+++ b/examples/DynamicBuffers/CMakeLists.txt
@@ -16,12 +16,14 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     endif()
 endif()
 
-add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
+if (NOT ANVIL_LINK_EXAMPLES)
+	add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
+endif()
 
 target_include_directories(Anvil PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/anvil/include")
 
 include_directories(${Anvil_SOURCE_DIR}/include
-                    ${DynamicBuffers_SOURCE_DIR}/include)
+                   ${DynamicBuffers_SOURCE_DIR}/include)
 
 # Include the Vulkan header.
 if (WIN32)

--- a/examples/DynamicBuffers/src/app.cpp
+++ b/examples/DynamicBuffers/src/app.cpp
@@ -478,7 +478,7 @@ void App::init_buffers()
 
     /* We also need some space for a uniform block which is going to hold time info. */
     const auto dynamic_ub_alignment_requirement                = m_device_ptr->get_physical_device_properties().core_vk1_0_properties_ptr->limits.min_uniform_buffer_offset_alignment;
-    const auto sine_props_data_buffer_size_per_swapchain_image = Anvil::Utils::round_up(sizeof(float),
+    const auto sine_props_data_buffer_size_per_swapchain_image = Anvil::Utils::round_up(static_cast<decltype(dynamic_ub_alignment_requirement)>(sizeof(float)),
                                                                                         dynamic_ub_alignment_requirement);
     const auto sine_props_data_buffer_size_total               = sine_props_data_buffer_size_per_swapchain_image * N_SWAPCHAIN_IMAGES;
 

--- a/examples/MultiViewport/CMakeLists.txt
+++ b/examples/MultiViewport/CMakeLists.txt
@@ -16,12 +16,11 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     endif()
 endif()
 
-add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
+if (NOT ANVIL_LINK_EXAMPLES)
+	add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")	
+endif()
 
 target_include_directories(Anvil PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/anvil/include")
-
-include_directories(${Anvil_SOURCE_DIR}/include
-                    ${MultiViewport_SOURCE_DIR}/include)
 
 if (WIN32)
     include_directories($ENV{VK_SDK_PATH}/Include
@@ -46,6 +45,9 @@ else()
                         $ENV{VULKAN_SDK}/lib
                         $ENV{VULKAN_SDK}/x86_64/lib)
 endif()
+
+include_directories(${Anvil_SOURCE_DIR}/include
+                    ${MultiViewport_SOURCE_DIR}/include)
 
 # Create the MultiViewport project.
 add_executable (MultiViewport include/app.h

--- a/examples/OcclusionQuery/CMakeLists.txt
+++ b/examples/OcclusionQuery/CMakeLists.txt
@@ -16,12 +16,11 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     endif()
 endif()
 
-add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
+if (NOT ANVIL_LINK_EXAMPLES)
+	add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
+endif()
 
 target_include_directories(Anvil PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/anvil/include")
-
-include_directories(${Anvil_SOURCE_DIR}/include
-                    ${OcclusionQuery_SOURCE_DIR}/include)
 
 # Include the Vulkan header.
 if (WIN32)
@@ -46,7 +45,10 @@ else()
     link_directories   ($ENV{VK_SDK_PATH}/x86_64/lib
                         $ENV{VULKAN_SDK}/lib
                         $ENV{VULKAN_SDK}/x86_64/lib)
-endif()
+endif()	
+
+include_directories(${Anvil_SOURCE_DIR}/include
+                    ${OcclusionQuery_SOURCE_DIR}/include)
 
 # Create the OcclusionQuery project.
 add_executable (OcclusionQuery include/app.h

--- a/examples/OcclusionQuery/src/app.cpp
+++ b/examples/OcclusionQuery/src/app.cpp
@@ -346,9 +346,9 @@ void App::init_buffers()
 {
     const VkDeviceSize uniform_alignment_req(m_physical_device_ptr->get_device_properties().core_vk1_0_properties_ptr->limits.min_uniform_buffer_offset_alignment);
 
-    m_n_bytes_per_query                = static_cast<uint32_t>(Anvil::Utils::round_up(sizeof(uint32_t),
+    m_n_bytes_per_query                = static_cast<uint32_t>(Anvil::Utils::round_up(static_cast<VkDeviceSize>(sizeof(uint32_t)),
                                                                                       uniform_alignment_req) );
-    m_time_n_bytes_per_swapchain_image = static_cast<uint32_t>(Anvil::Utils::round_up(sizeof(float),
+    m_time_n_bytes_per_swapchain_image = static_cast<uint32_t>(Anvil::Utils::round_up(static_cast<VkDeviceSize>(sizeof(float)),
                                                                                       uniform_alignment_req) );
 
     {

--- a/examples/OutOfOrderRasterization/CMakeLists.txt
+++ b/examples/OutOfOrderRasterization/CMakeLists.txt
@@ -16,7 +16,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     endif()
 endif()
 
-add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
+if (NOT ANVIL_LINK_EXAMPLES)
+	add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
+endif()
 
 target_include_directories(Anvil PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/anvil/include")
 

--- a/examples/PushConstants/CMakeLists.txt
+++ b/examples/PushConstants/CMakeLists.txt
@@ -16,7 +16,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     endif()
 endif()
 
-add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
+if (NOT ANVIL_LINK_EXAMPLES)
+	add_subdirectory   (../.. "${CMAKE_CURRENT_BINARY_DIR}/anvil")
+endif()
 
 target_include_directories(Anvil PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/anvil/include")
 

--- a/src/wrappers/image.cpp
+++ b/src/wrappers/image.cpp
@@ -880,7 +880,7 @@ const VkImage& Anvil::Image::get_image(const bool& in_bake_memory_if_necessary)
 /* Please see header for specification */
 VkExtent2D Anvil::Image::get_image_extent_2D(uint32_t in_n_mipmap) const
 {
-    VkExtent2D result;
+	VkExtent2D result = { 0u, 0u };
     uint32_t   size[2];
 
     if (!get_image_mipmap_size(in_n_mipmap,
@@ -903,7 +903,7 @@ end:
 /* Please see header for specification */
 VkExtent3D Anvil::Image::get_image_extent_3D(uint32_t in_n_mipmap) const
 {
-    VkExtent3D result;
+	VkExtent3D result = { 0u, 0u, 0u };
     uint32_t   size[3];
 
     if (!get_image_mipmap_size(in_n_mipmap,


### PR DESCRIPTION
- Cmake ANVIL_LINK_EXAMPLES include examples Alvin 
Adds option (ANVIL_LINK_EXAMPLES ) for build Anvil with examples inside. 

- Fix warn: potentially uninitialized variable used
- Fix round_up arguments cast