### PR TITLE
Fixed inconsistent names for CullModeFlagBits

### DIFF
--- a/include/misc/types_enums.h
+++ b/include/misc/types_enums.h
@@ -646,13 +646,11 @@ namespace Anvil
     /* NOTE: These map 1:1 to VK equivalents */
     enum class CullModeFlagBits
     {
-        CULL_MODE_BACK_BIT  = VK_CULL_MODE_BACK_BIT,
-        CULL_MODE_FRONT_BIT = VK_CULL_MODE_FRONT_BIT,
-        CULL_MODE_NONE      = VK_CULL_MODE_NONE,
+        BACK_BIT  = VK_CULL_MODE_BACK_BIT,
+        FRONT_BIT = VK_CULL_MODE_FRONT_BIT,
+        NONE      = VK_CULL_MODE_NONE,
 
-        CULL_MODE_FRONT_AND_BACK = VK_CULL_MODE_FRONT_AND_BACK,
-
-        NONE = 0
+        FRONT_AND_BACK = VK_CULL_MODE_FRONT_AND_BACK
     };
     typedef Anvil::Bitfield<Anvil::CullModeFlagBits, VkCullModeFlags> CullModeFlags;
 

--- a/src/misc/graphics_pipeline_create_info.cpp
+++ b/src/misc/graphics_pipeline_create_info.cpp
@@ -75,7 +75,7 @@ Anvil::GraphicsPipelineCreateInfo::GraphicsPipelineCreateInfo(const RenderPass* 
            0,
            sizeof(m_blend_constant) );
 
-    m_cull_mode          = Anvil::CullModeFlagBits::CULL_MODE_BACK_BIT;
+    m_cull_mode          = Anvil::CullModeFlagBits::BACK_BIT;
     m_line_width         = 1.0f;
     m_min_sample_shading = 1.0f;
     m_sample_count       = Anvil::SampleCountFlagBits::_1_BIT;


### PR DESCRIPTION
Removed the _CULL_MODE__-prefixes from the _CullModeFlagBits_ enum names to make them consistent with the other enum classes.