### PR TITLE
Remove superfluous const from simple return types

### DIFF
--- a/include/misc/buffer_create_info.h
+++ b/include/misc/buffer_create_info.h
@@ -104,7 +104,7 @@ namespace Anvil
                                                                       VkDeviceSize   in_start_offset,
                                                                       VkDeviceSize   in_size);
 
-        const void* const get_client_data() const
+        const void* get_client_data() const
         {
             return m_client_data_ptr;
         }

--- a/include/misc/glsl_to_spirv.h
+++ b/include/misc/glsl_to_spirv.h
@@ -305,7 +305,7 @@ namespace Anvil
          }
 
          /** Returns the number of bytes the SPIR-V blob, accessible via get_spirv_blob(), takes. */
-         const uint32_t get_spirv_blob_size() const
+         uint32_t get_spirv_blob_size() const
          {
              if (m_spirv_blob.size() == 0)
              {

--- a/include/misc/image_view_create_info.h
+++ b/include/misc/image_view_create_info.h
@@ -295,7 +295,7 @@ namespace Anvil
         }
 
         /** Returns image view's format */
-        const Anvil::Format get_format() const
+        Anvil::Format get_format() const
         {
             return m_format;
         }
@@ -330,7 +330,7 @@ namespace Anvil
         }
 
         /** Returns image view type of the image view instance */
-        const Anvil::ImageViewType get_type() const
+        Anvil::ImageViewType get_type() const
         {
             return m_type;
         }

--- a/include/misc/struct_chainer.h
+++ b/include/misc/struct_chainer.h
@@ -79,7 +79,7 @@ namespace Anvil
             struct_chain_ptrs.push_back(std::move(inout_struct_chain_ptr) );
         }
 
-        const uint32_t get_n_structs() const
+        uint32_t get_n_structs() const
         {
             return static_cast<uint32_t>(root_structs.size() );
         }

--- a/include/wrappers/command_buffer.h
+++ b/include/wrappers/command_buffer.h
@@ -319,7 +319,7 @@ namespace Anvil
         }
 
         /** Returns a handle to the raw Vulkan command buffer instance, encapsulated by the object */
-        const VkCommandBuffer get_command_buffer() const
+        VkCommandBuffer get_command_buffer() const
         {
             return m_command_buffer;
         }

--- a/include/wrappers/framebuffer.h
+++ b/include/wrappers/framebuffer.h
@@ -60,7 +60,7 @@ namespace Anvil
          *
          *  @return Raw Vulkan framebuffer handle or VK_NULL_HANDLE, if the function failed.
          **/
-        const VkFramebuffer get_framebuffer(Anvil::RenderPass* in_render_pass_ptr);
+        VkFramebuffer get_framebuffer(Anvil::RenderPass* in_render_pass_ptr);
 
     private:
         /* Private type declarations */

--- a/include/wrappers/image_view.h
+++ b/include/wrappers/image_view.h
@@ -65,7 +65,7 @@ namespace Anvil
         }
 
         /** Returns the encapsulated raw Vulkan image view handle. */
-        const VkImageView get_image_view() const
+        VkImageView get_image_view() const
         {
             return m_image_view;
         }

--- a/src/wrappers/framebuffer.cpp
+++ b/src/wrappers/framebuffer.cpp
@@ -202,7 +202,7 @@ Anvil::FramebufferUniquePtr Anvil::Framebuffer::create(Anvil::FramebufferCreateI
 }
 
 /* Please see header for specification */
-const VkFramebuffer Anvil::Framebuffer::get_framebuffer(Anvil::RenderPass* in_render_pass_ptr)
+VkFramebuffer Anvil::Framebuffer::get_framebuffer(Anvil::RenderPass* in_render_pass_ptr)
 {
     auto          fb_iterator = m_baked_framebuffers.find(in_render_pass_ptr);
     VkFramebuffer result_fb   = VK_NULL_HANDLE;


### PR DESCRIPTION
cf. https://isocpp.org/blog/2013/06/quick-q-should-i-return-a-const-value-stackoverflow