### PR TITLE
Properly zero-initialise objects

### DIFF
--- a/deps/glslang/SPIRV/bitutils.h
+++ b/deps/glslang/SPIRV/bitutils.h
@@ -26,7 +26,7 @@ Dest BitwiseCast(Src source) {
   Dest dest;
   static_assert(sizeof(source) == sizeof(dest),
                 "BitwiseCast: Source and destination must have the same size");
-  std::memcpy(&dest, &source, sizeof(dest));
+  std::memcpy(static_cast<void *>(&dest), &source, sizeof(dest));
   return dest;
 }
 

--- a/include/wrappers/rendering_surface.h
+++ b/include/wrappers/rendering_surface.h
@@ -158,7 +158,7 @@ namespace Anvil
 
         typedef struct PhysicalDeviceCapabilities
         {
-            Anvil::SurfaceCapabilities          capabilities;
+            Anvil::SurfaceCapabilities          capabilities{};
             std::vector<RenderingSurfaceFormat> supported_formats;
             std::vector<Anvil::PresentModeKHR>  supported_presentation_modes;
             Anvil::SurfaceTransformFlags        supported_transformations;
@@ -167,13 +167,6 @@ namespace Anvil
             std::vector<uint32_t>               present_capable_queue_fams;
 
             Anvil::CompositeAlphaFlags          supported_composite_alpha_flags;
-
-            PhysicalDeviceCapabilities()
-            {
-                memset(&capabilities,
-                       0,
-                       sizeof(capabilities) );
-            }
         } PhysicalDeviceCapabilities;
 
         /* Private functions */

--- a/src/misc/types_struct.cpp
+++ b/src/misc/types_struct.cpp
@@ -1316,11 +1316,7 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_1D(Anvil::ImageAspectFlagBits 
                                                      uint32_t                   in_n_mipmap,
                                                      uint32_t                   in_row_size)
 {
-    MipmapRawData result;
-
-    memset(&result,
-            0,
-            sizeof(result) );
+    MipmapRawData result{};
 
     result.aspect    = in_aspect;
     result.data_size = in_row_size;
@@ -1343,11 +1339,7 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_1D_array(Anvil::ImageAspectFla
                                                            uint32_t                   in_row_size,
                                                            uint32_t                   in_data_size)
 {
-    MipmapRawData result;
-
-    memset(&result,
-            0,
-            sizeof(result) );
+    MipmapRawData result{};
 
     result.aspect    = in_aspect;
     result.data_size = in_data_size;
@@ -1369,11 +1361,7 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_2D(Anvil::ImageAspectFlagBits 
                                                      uint32_t                   in_data_size,
                                                      uint32_t                   in_row_size)
 {
-    MipmapRawData result;
-
-    memset(&result,
-            0,
-            sizeof(result) );
+    MipmapRawData result{};
 
     result.aspect    = in_aspect;
     result.data_size = in_data_size;
@@ -1396,11 +1384,7 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_2D_array(Anvil::ImageAspectFla
                                                            uint32_t                   in_data_size,
                                                            uint32_t                   in_row_size)
 {
-    MipmapRawData result;
-
-    memset(&result,
-            0,
-            sizeof(result) );
+    MipmapRawData result{};
 
     result.aspect    = in_aspect;
     result.data_size = in_data_size;
@@ -1424,11 +1408,7 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_3D(Anvil::ImageAspectFlagBits 
                                                      uint32_t                   in_data_size,
                                                      uint32_t                   in_row_size)
 {
-    MipmapRawData result;
-
-    memset(&result,
-            0,
-            sizeof(result) );
+    MipmapRawData result{};
 
     result.aspect    = in_aspect;
     result.data_size = in_data_size;


### PR DESCRIPTION
Rather than trying to cheat compiler into forcefully zeroing memory, like https://github.com/GPUOpen-LibrariesAndSDKs/Anvil/pull/128 tries to do, properly zero-initialise the relevant objects.

Fixes #125 
Closes #128