### PR TITLE
GCC 8 compatibility fix

### DIFF
--- a/src/misc/types_struct.cpp
+++ b/src/misc/types_struct.cpp
@@ -1988,10 +1988,6 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_1D(Anvil::ImageAspectFlagBits 
 {
     MipmapRawData result;
 
-    memset(&result,
-            0,
-            sizeof(result) );
-
     result.aspect    = in_aspect;
     result.data_size = in_row_size;
     result.row_size  = in_row_size;
@@ -2015,10 +2011,6 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_1D_array(Anvil::ImageAspectFla
 {
     MipmapRawData result;
 
-    memset(&result,
-            0,
-            sizeof(result) );
-
     result.aspect    = in_aspect;
     result.data_size = in_data_size;
     result.n_layer   = in_n_layer;
@@ -2040,10 +2032,6 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_2D(Anvil::ImageAspectFlagBits 
                                                      uint32_t                   in_row_size)
 {
     MipmapRawData result;
-
-    memset(&result,
-            0,
-            sizeof(result) );
 
     result.aspect    = in_aspect;
     result.data_size = in_data_size;
@@ -2067,11 +2055,7 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_2D_array(Anvil::ImageAspectFla
                                                            uint32_t                   in_row_size)
 {
     MipmapRawData result;
-
-    memset(&result,
-            0,
-            sizeof(result) );
-
+    
     result.aspect    = in_aspect;
     result.data_size = in_data_size;
     result.n_layer   = in_n_layer;
@@ -2095,10 +2079,6 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_3D(Anvil::ImageAspectFlagBits 
                                                      uint32_t                   in_row_size)
 {
     MipmapRawData result;
-
-    memset(&result,
-            0,
-            sizeof(result) );
 
     result.aspect    = in_aspect;
     result.data_size = in_data_size;


### PR DESCRIPTION
MipmapRawData already has a default constructor that set all values to 0/nullptr. Even if the memset did the same GCC 8 throws errors. Now it does not.