### PR TITLE
Bug-fixes and improvements.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,20 @@ option(ANVIL_INCLUDE_XCB_WINDOW_SYSTEM_SUPPORT     "Includes XCB window system s
 option(ANVIL_LINK_EXAMPLES                         "Build examples showing how to use Anvil" OFF)
 option(ANVIL_LINK_STATICALLY_WITH_VULKAN_LIB       "Link statically with Vulkan loader. If disabled, Anvil will load the func ptrs from ANVIL_VULKAN_DYNAMIC_DLL_DEPENDENCY at VK instance creation time" ON)
 option(ANVIL_LINK_WITH_GLSLANG                     "Links with glslang, instead of spawning a new process whenever GLSL->SPIR-V conversion is required" ON)
+option(ANVIL_USE_BUILT_IN_GLSLANG                  "Use glslang version included with Anvil. If disabled, Anvil will assume ANVIL_GLSLANG_PATH holds path to library's root directory." ON)
 option(ANVIL_USE_BUILT_IN_VULKAN_HEADERS           "Use built-in Vulkan headers. If disabled, VK_SDK_PATH and VULKAN_SDK env vars will be assumed to hold the location where the headers can be found." ON)
-
 
 if (MSVC)
     set (DEFAULT_DYNAMIC_VK_DLL "vulkan-1.dll")
 else()
     set (DEFAULT_DYNAMIC_VK_DLL "libvulkan.so")
+endif()
+
+if (ANVIL_USE_BUILT_IN_GLSLANG)
+    set(ANVIL_GLSLANG_PATH "${Anvil_SOURCE_DIR}/deps/glslang")
+else()
+    set(ANVIL_GLSLANG_PATH "${Anvil_SOURCE_DIR}/deps/glslang"
+                            CACHE STRING "Path to glslang directory")
 endif()
 
 if (NOT ANVIL_LINK_STATICALLY_WITH_VULKAN_LIB)
@@ -31,6 +38,7 @@ configure_file("include/config.h.in" "include/config.h")
 include_directories("${Anvil_BINARY_DIR}/include"
                     "${Anvil_SOURCE_DIR}"
                     "${Anvil_SOURCE_DIR}/deps"
+                    "${ANVIL_GLSLANG_PATH}"
                     "${Anvil_SOURCE_DIR}/include")
 
 # Include the Vulkan header.
@@ -261,7 +269,7 @@ if (WIN32)
         target_link_libraries(Anvil glslang OGLCompiler OSDependent SPIRV ${VULKAN_LIBRARY})
     else()
         target_link_libraries(Anvil ${VULKAN_LIBRARY})
-endif()
+    endif()
 else()
     if (ANVIL_LINK_WITH_GLSLANG)
         target_link_libraries(Anvil glslang OGLCompiler OSDependent SPIRV ${VULKAN_LIBRARY} pthread)
@@ -281,11 +289,7 @@ if (ANVIL_LINK_WITH_GLSLANG)
     set(ENABLE_HLSL   OFF CACHE BOOL ".." FORCE)
     set(ENABLE_OPT    OFF CACHE BOOL ".." FORCE)
 
-    if (WIN32)
-        add_subdirectory("deps\\glslang")
-    else()
-        add_subdirectory("deps/glslang")
-    endif()
+    add_subdirectory("${ANVIL_GLSLANG_PATH}")
 endif()
 
 if (ANVIL_LINK_EXAMPLES)

--- a/examples/DynamicBuffers/src/app.cpp
+++ b/examples/DynamicBuffers/src/app.cpp
@@ -880,8 +880,7 @@ void App::init_dsgs()
 
     /* Create the descriptor set layouts for the generator program. */
     m_producer_dsg_ptr = Anvil::DescriptorSetGroup::create(m_device_ptr.get(),
-                                                           producer_dsg_create_info_ptrs,
-                                                           false); /* releaseable_sets */
+                                                           producer_dsg_create_info_ptrs);
 
 
     m_producer_dsg_ptr->set_binding_item(0, /* n_set         */
@@ -902,8 +901,7 @@ void App::init_dsgs()
 
     /* Set up the descriptor set layout for the renderer program.  */
     m_consumer_dsg_ptr = Anvil::DescriptorSetGroup::create(m_device_ptr.get(),
-                                                           consumer_dsg_create_info_ptrs,
-                                                           false); /* releaseable_sets */
+                                                           consumer_dsg_create_info_ptrs);
 
 
     m_consumer_dsg_ptr->set_binding_item(0, /* n_set         */
@@ -1019,11 +1017,18 @@ void App::init_gfx_pipelines()
                                                                                 Anvil::ShaderModuleStageEntryPoint(), /* tess_evaluation_shader */
                                                                                *m_consumer_vs_ptr);
 
-    consumer_pipeline_info_ptr->add_vertex_attribute          (0, /* location */
-                                                               Anvil::Format::R8G8_UNORM,
-                                                               0,                /* offset_in_bytes */
-                                                               sizeof(char) * 2, /* stride_in_bytes */
-                                                               Anvil::VertexInputRate::INSTANCE);
+    {
+        Anvil::VertexInputAttribute attribute(0,                         /* in_location        */
+                                              Anvil::Format::R8G8_UNORM,
+                                              0);                        /* in_offset_in_bytes */
+
+        consumer_pipeline_info_ptr->add_vertex_binding(0,                                /* in_binding */
+                                                       Anvil::VertexInputRate::INSTANCE,
+                                                       sizeof(char) * 2,                 /* in_stride_in_bytes */
+                                                       1,                                /* in_attribute_ptrs  */
+                                                      &attribute);
+    }
+
     consumer_pipeline_info_ptr->set_descriptor_set_create_info(m_consumer_dsg_ptr->get_descriptor_set_create_info() );
     consumer_pipeline_info_ptr->set_primitive_topology        (Anvil::PrimitiveTopology::LINE_STRIP);
     consumer_pipeline_info_ptr->set_rasterization_properties  (Anvil::PolygonMode::FILL,

--- a/examples/MultiViewport/src/app.cpp
+++ b/examples/MultiViewport/src/app.cpp
@@ -736,36 +736,65 @@ void App::init_gfx_pipelines()
                                                                Anvil::DynamicState::VIEWPORT);
     gfx_pipeline_create_info_ptr->toggle_primitive_restart    (true /* should_enable */);
 
-    gfx_pipeline_create_info_ptr->add_vertex_attribute(g_vertex_attribute_location,
-                                                       mesh_vertex_data_format,
-                                                       0,                                        /* offset_in_bytes */
-                                                       sizeof(float) * n_mesh_vertex_components, /* stride_in_bytes */
-                                                       Anvil::VertexInputRate::VERTEX,
-                                                       g_vertex_attribute_binding);
-    gfx_pipeline_create_info_ptr->add_vertex_attribute(g_color1_attribute_location,
-                                                       mesh_color_data_format,
-                                                       0,                                       /* offset_in_bytes */
-                                                       sizeof(float) * n_mesh_color_components, /* stride_in_bytes */
-                                                       Anvil::VertexInputRate::VERTEX,
-                                                       g_color1_attribute_binding);
-    gfx_pipeline_create_info_ptr->add_vertex_attribute(g_color2_attribute_location,
-                                                       mesh_color_data_format,
-                                                       0,                                       /* offset_in_bytes */
-                                                       sizeof(float) * n_mesh_color_components, /* stride_in_bytes */
-                                                       Anvil::VertexInputRate::VERTEX,
-                                                       g_color2_attribute_binding);
-    gfx_pipeline_create_info_ptr->add_vertex_attribute(g_color3_attribute_location,
-                                                       mesh_color_data_format,
-                                                       0,                                       /* offset_in_bytes */
-                                                       sizeof(float) * n_mesh_color_components, /* stride_in_bytes */
-                                                       Anvil::VertexInputRate::VERTEX,
-                                                       g_color3_attribute_binding);
-    gfx_pipeline_create_info_ptr->add_vertex_attribute(g_color4_attribute_location,
-                                                       mesh_color_data_format,
-                                                       0,                                       /* offset_in_bytes */
-                                                       sizeof(float) * n_mesh_color_components, /* stride_in_bytes */
-                                                       Anvil::VertexInputRate::VERTEX,
-                                                       g_color4_attribute_binding);
+    {
+        Anvil::VertexInputAttribute attribute(g_vertex_attribute_location,
+                                              mesh_vertex_data_format,
+                                              0);                          /* in_offset_in_bytes */
+
+        gfx_pipeline_create_info_ptr->add_vertex_binding(g_vertex_attribute_binding,
+                                                         Anvil::VertexInputRate::VERTEX,
+                                                         sizeof(float) * n_mesh_vertex_components, /* in_stride_in_bytes */
+                                                         1, /* in_n_attributes */
+                                                        &attribute);
+    }
+
+    {
+        Anvil::VertexInputAttribute attribute(g_color1_attribute_location,
+                                              mesh_color_data_format,
+                                              0);                          /* in_offset_in_bytes */
+
+        gfx_pipeline_create_info_ptr->add_vertex_binding(g_color1_attribute_binding,
+                                                         Anvil::VertexInputRate::VERTEX,
+                                                         sizeof(float) * n_mesh_color_components, /* in_stride_in_bytes */
+                                                         1, /* in_n_attributes */
+                                                        &attribute);
+    }
+
+    {
+        Anvil::VertexInputAttribute attribute(g_color2_attribute_location,
+                                              mesh_color_data_format,
+                                              0);                          /* in_offset_in_bytes */
+
+        gfx_pipeline_create_info_ptr->add_vertex_binding(g_color2_attribute_binding,
+                                                         Anvil::VertexInputRate::VERTEX,
+                                                         sizeof(float) * n_mesh_color_components, /* in_stride_in_bytes */
+                                                         1, /* in_n_attributes */
+                                                        &attribute);
+    }
+
+    {
+        Anvil::VertexInputAttribute attribute(g_color3_attribute_location,
+                                              mesh_color_data_format,
+                                              0);                          /* in_offset_in_bytes */
+
+        gfx_pipeline_create_info_ptr->add_vertex_binding(g_color3_attribute_binding,
+                                                         Anvil::VertexInputRate::VERTEX,
+                                                         sizeof(float) * n_mesh_color_components, /* in_stride_in_bytes */
+                                                         1, /* in_n_attributes */
+                                                        &attribute);
+    }
+
+    {
+        Anvil::VertexInputAttribute attribute(g_color4_attribute_location,
+                                              mesh_color_data_format,
+                                              0);                          /* in_offset_in_bytes */
+
+        gfx_pipeline_create_info_ptr->add_vertex_binding(g_color4_attribute_binding,
+                                                         Anvil::VertexInputRate::VERTEX,
+                                                         sizeof(float) * n_mesh_color_components, /* in_stride_in_bytes */
+                                                         1, /* in_n_attributes */
+                                                        &attribute);
+    }
 
     for (uint32_t n_scissor_box = 0;
                   n_scissor_box < sizeof(scissors) / sizeof(scissors[0]);

--- a/examples/OcclusionQuery/src/app.cpp
+++ b/examples/OcclusionQuery/src/app.cpp
@@ -627,14 +627,11 @@ void App::init_dsgs()
                                                       Anvil::ShaderStageFlagBits::VERTEX_BIT);
 
     m_1stpass_dsg_ptr      = Anvil::DescriptorSetGroup::create(m_device_ptr.get(),
-                                                               dsg_1stpass_create_info_ptrs,
-                                                               false); /* in_releaseable_sets */
+                                                               dsg_1stpass_create_info_ptrs);
     m_2ndpass_tri_dsg_ptr  = Anvil::DescriptorSetGroup::create(m_device_ptr.get(),
-                                                               tri_dsg_2ndpass_create_info_ptrs,
-                                                               false); /* in_releaseable_sets */
+                                                               tri_dsg_2ndpass_create_info_ptrs);
     m_2ndpass_quad_dsg_ptr = Anvil::DescriptorSetGroup::create(m_device_ptr.get(),
-                                                               quad_dsg_2ndpass_create_info_ptrs,
-                                                               false); /* in_releaseable_sets */
+                                                               quad_dsg_2ndpass_create_info_ptrs);
 
     m_1stpass_dsg_ptr->set_binding_item     (0, /* n_set         */
                                              0, /* binding_index */

--- a/examples/OutOfOrderRasterization/src/app.cpp
+++ b/examples/OutOfOrderRasterization/src/app.cpp
@@ -1441,8 +1441,7 @@ void App::init_dsgs()
                                                     Anvil::ShaderStageFlagBits::VERTEX_BIT);
 
             new_dsg_ptr = Anvil::DescriptorSetGroup::create(m_device_ptr.get(),
-                                                            new_dsg_create_info_ptr,
-                                                            false); /* in_releaseable_sets */
+                                                            new_dsg_create_info_ptr);
         }
 
         new_dsg_ptr->set_binding_item(0, /* n_set         */
@@ -1482,11 +1481,17 @@ void App::init_gfx_pipelines()
                                                                                       Anvil::ShaderModuleStageEntryPoint(), /* in_te_entrypoint */
                                                                                      *m_vs_entrypoint_ptr);
 
-            pipeline_create_info_ptr->add_vertex_attribute(0, /* location */
-                                                           Anvil::Format::R32G32B32_SFLOAT,
-                                                           0,                 /* offset_in_bytes */
-                                                           sizeof(float) * 3, /* stride_in_bytes */
-                                                           Anvil::VertexInputRate::VERTEX);
+            {
+                auto attribute = Anvil::VertexInputAttribute(0,                               /* location        */
+                                                             Anvil::Format::R32G32B32_SFLOAT,
+                                                             0);                              /* offset_in_bytes */
+
+                pipeline_create_info_ptr->add_vertex_binding(0,                             /* in_binding         */
+                                                             Anvil::VertexInputRate::VERTEX,
+                                                             sizeof(float) * 3,             /* in_stride_in_bytes */
+                                                             1, /* in_n_attributes */
+                                                            &attribute);
+            }
 
             pipeline_create_info_ptr->set_descriptor_set_create_info(m_dsg_ptrs[0]->get_descriptor_set_create_info() );
 
@@ -1708,11 +1713,18 @@ void App::init_renderpasses()
                                                                                             Anvil::ShaderModuleStageEntryPoint(), /* in_te_entrypoint */
                                                                                            *m_vs_entrypoint_ptr);
 
-            gfx_pipeline_create_info_ptr->add_vertex_attribute          (0, /* location */
-                                                                         Anvil::Format::R32G32B32_SFLOAT,
-                                                                         0,                 /* offset_in_bytes */
-                                                                         sizeof(float) * 3, /* stride_in_bytes */
-                                                                         Anvil::VertexInputRate::VERTEX);
+            {
+                auto attribute = Anvil::VertexInputAttribute(0,                               /* location        */
+                                                             Anvil::Format::R32G32B32_SFLOAT,
+                                                             0);                              /* offset_in_bytes */
+
+                gfx_pipeline_create_info_ptr->add_vertex_binding(0,                              /* in_binding      */
+                                                                 Anvil::VertexInputRate::VERTEX,
+                                                                 sizeof(float) * 3,              /* stride_in_bytes */
+                                                                 1,                              /* in_n_attributes */
+                                                                &attribute);
+            }
+
             gfx_pipeline_create_info_ptr->set_descriptor_set_create_info(m_dsg_ptrs[0]->get_descriptor_set_create_info() );
 
             gfx_manager_ptr->add_pipeline(std::move(gfx_pipeline_create_info_ptr),

--- a/include/misc/device_create_info.h
+++ b/include/misc/device_create_info.h
@@ -38,8 +38,9 @@ namespace Anvil
          * Anvil creates one command pool per each queue family which apps can use at any time which is why the CommandPoolCreateFlags argument
          * is present.
          *
-         * By default, the device will be created with API version equal to min(instance-level API version, physical device API version}.
-         * This can be overridden by calling set_api_version().
+         * NOTE: By default, an empty pipeline cache will be created for pipeline manager usage. You can adjust this behavior, allowing for
+         *       pipeline cache reuse across executions, by calling set_pipeline_cache_ptr() and retrieving pipeline cache data and caching it
+         *       at later time.
          *
          * NOTE: If VK_EXT_global_queue_priority is supported, all queues are associated MEDIUM_EXT global priority by default.
          *       This can be changed on a per-queue basis by calling set_queue_global_priority() prior to passing the structure
@@ -100,6 +101,11 @@ namespace Anvil
         const std::vector<const Anvil::PhysicalDevice*>& get_physical_device_ptrs() const
         {
             return m_physical_device_ptrs;
+        }
+
+        Anvil::PipelineCache* get_pipeline_cache_ptr() const
+        {
+            return m_pipeline_cache_ptr.get();
         }
 
         Anvil::QueueGlobalPriority get_queue_global_priority(const uint32_t& in_queue_family_index,
@@ -186,6 +192,12 @@ namespace Anvil
             m_queue_properties[in_queue_family_index][in_queue_index].global_priority = in_queue_global_priority;
         }
 
+        /* Caches user-specified pipeline cache for usage with pipeline managers. */
+        void set_pipeline_cache_ptr(Anvil::PipelineCacheUniquePtr in_pipeline_cache_ptr)
+        {
+            m_pipeline_cache_ptr = std::move(in_pipeline_cache_ptr);
+        }
+
         /* Associates priority with a given <queue family index, queue index> pair.
          *
          * By default, all queues will be associated a priority of 0.0.
@@ -264,6 +276,7 @@ namespace Anvil
         Anvil::MemoryOverallocationBehavior                                          m_memory_overallocation_behavior;
         bool                                                                         m_mt_safe;
         std::vector<const Anvil::PhysicalDevice*>                                    m_physical_device_ptrs;
+        Anvil::PipelineCacheUniquePtr                                                m_pipeline_cache_ptr;
         std::unordered_map<uint32_t, std::unordered_map<uint32_t, QueueProperties> > m_queue_properties;
         bool                                                                         m_should_enable_shader_module_cache;
 

--- a/include/misc/glsl_to_spirv.h
+++ b/include/misc/glsl_to_spirv.h
@@ -44,7 +44,7 @@
         #pragma warning(disable: 4464)
     #endif
 
-    #include "../../deps/glslang/glslang/Public/ShaderLang.h"
+    #include "glslang/Public/ShaderLang.h"
 
     #ifdef _MSC_VER
         #pragma warning(pop)

--- a/include/misc/types_struct.h
+++ b/include/misc/types_struct.h
@@ -3391,6 +3391,31 @@ namespace Anvil
     static_assert(offsetof(SurfaceFormatKHR, format)      == offsetof(VkSurfaceFormatKHR, format),     "Member offsets must match");
     static_assert(offsetof(SurfaceFormatKHR, color_space) == offsetof(VkSurfaceFormatKHR, colorSpace), "Member offsets must match");
 
+    typedef struct VertexInputAttribute
+    {
+        Anvil::Format format;
+        uint32_t      location;
+        uint32_t      offset_in_bytes;
+
+        VertexInputAttribute()
+            :format         (Anvil::Format::UNKNOWN),
+             location       (UINT32_MAX),
+             offset_in_bytes(UINT32_MAX)
+        {
+            /* Stub */
+        }
+
+        VertexInputAttribute(const uint32_t&      in_location,
+                             const Anvil::Format& in_format,
+                             const uint32_t&      in_offset_in_bytes)
+            :format         (in_format),
+             location       (in_location),
+             offset_in_bytes(in_offset_in_bytes)
+        {
+            /* Stub */
+        }
+    } VertexInputAttribute;
+
     /* Represents a Vulkan structure header */
     typedef struct
     {

--- a/include/wrappers/descriptor_set_group.h
+++ b/include/wrappers/descriptor_set_group.h
@@ -98,17 +98,18 @@ namespace Anvil
          *  takes a ptr to DescriptorSetGroup instance, causing objects created in such fashion to treat the
          *  specified DescriptorSetGroup instance as a parent.
          *
-         *  @param in_device_ptr           Device to use.
-         *  @param in_ds_create_info_ptrs  TODO.
-         *  @param in_opt_pool_extra_flags Flags to include when creating a descriptor pool. Note that DSG may also specify
-         *                                 other flags not included in this set, too.
+         *  @param in_device_ptr                   Device to use.
+         *  @param in_ds_create_info_ptrs          TODO.
+         *  @param in_descriptor_pool_create_flags Create flags to specify when creating a descriptor pool for the DSG.
+         *  @param in_mt_safety                    MT safety setting for the created object.
+         *  @param in_opt_overhead_allocations     Extra allocations to request when creating a descriptor pool for the DSG.
          */
         static Anvil::DescriptorSetGroupUniquePtr create(const Anvil::BaseDevice*                              in_device_ptr,
                                                          std::vector<Anvil::DescriptorSetCreateInfoUniquePtr>& in_ds_create_info_ptrs,
-                                                         bool                                                  in_releaseable_sets,
-                                                         MTSafety                                              in_mt_safety                = Anvil::MTSafety::INHERIT_FROM_PARENT_DEVICE,
-                                                         const std::vector<OverheadAllocation>&                in_opt_overhead_allocations = std::vector<OverheadAllocation>(),
-                                                         const Anvil::DescriptorPoolCreateFlags&               in_opt_pool_extra_flags     = Anvil::DescriptorPoolCreateFlagBits::NONE);
+                                                         const Anvil::DescriptorPoolCreateFlags&               in_descriptor_pool_create_flags = Anvil::DescriptorPoolCreateFlagBits::NONE,
+                                                         MTSafety                                              in_mt_safety                    = Anvil::MTSafety::INHERIT_FROM_PARENT_DEVICE,
+                                                         const std::vector<OverheadAllocation>&                in_opt_overhead_allocations     = std::vector<OverheadAllocation>() );
+                                                         
 
         /** Creates a new DescriptorSetGroup instance.
          *
@@ -116,11 +117,9 @@ namespace Anvil
          *  to re-use layout of another DSG. This is useful if you'd like to re-use the same layout with
          *  a different combination of descriptor sets.
          *
-         *  @param in_parent_dsg_ptr   Pointer to a DSG without a parent. Must not be nullptr.
-         *  @param in_releaseable_sets See the documentation above for more details.
+         *  @param in_parent_dsg_ptr Pointer to a DSG without a parent. Must not be nullptr.
          **/
-        static DescriptorSetGroupUniquePtr create(const DescriptorSetGroup* in_parent_dsg_ptr,
-                                                  bool                      in_releaseable_sets);
+        static DescriptorSetGroupUniquePtr create(const DescriptorSetGroup* in_parent_dsg_ptr);
 
         /** Retrieves a Vulkan instance of the descriptor set, as configured for the DSG instance's set
          *  at index @param in_n_set.
@@ -328,14 +327,12 @@ namespace Anvil
         /** Please see create() documentation for more details. */
         DescriptorSetGroup(const Anvil::BaseDevice*                      in_device_ptr,
                            std::vector<DescriptorSetCreateInfoUniquePtr> in_ds_create_info_ptrs,
-                           bool                                          in_releaseable_sets,
+                           const Anvil::DescriptorPoolCreateFlags&       in_descriptor_pool_create_flags,
                            MTSafety                                      in_mt_safety                = Anvil::MTSafety::INHERIT_FROM_PARENT_DEVICE,
-                           const std::vector<OverheadAllocation>&        in_opt_overhead_allocations = std::vector<OverheadAllocation>(),
-                           const Anvil::DescriptorPoolCreateFlags&       in_opt_pool_extra_flags     = Anvil::DescriptorPoolCreateFlagBits::NONE);
+                           const std::vector<OverheadAllocation>&        in_opt_overhead_allocations = std::vector<OverheadAllocation>() );
 
         /** Please see create() documentation for more details. */
-        DescriptorSetGroup(const DescriptorSetGroup* in_parent_dsg_ptr,
-                           bool                      in_releaseable_sets);
+        DescriptorSetGroup(const DescriptorSetGroup* in_parent_dsg_ptr);
 
         bool bake_descriptor_pool();
         bool bake_descriptor_sets();
@@ -348,10 +345,9 @@ namespace Anvil
 
         std::unordered_map<Anvil::DescriptorType, DescriptorTypeProperties, EnumClassHasher<Anvil::DescriptorType> > m_descriptor_type_properties;
 
+        const Anvil::DescriptorPoolCreateFlags m_descriptor_pool_create_flags;
         uint32_t                               m_n_unique_dses;
         const Anvil::DescriptorSetGroup*       m_parent_dsg_ptr;
-        bool                                   m_releaseable_sets;
-        const Anvil::DescriptorPoolCreateFlags m_user_specified_pool_flags;
 
         ANVIL_DISABLE_ASSIGNMENT_OPERATOR(DescriptorSetGroup);
         ANVIL_DISABLE_COPY_CONSTRUCTOR(DescriptorSetGroup);

--- a/include/wrappers/graphics_pipeline_manager.h
+++ b/include/wrappers/graphics_pipeline_manager.h
@@ -108,7 +108,6 @@ namespace Anvil
 
         typedef struct GraphicsPipelineData
         {
-            AttributeLocationToBindingIndexMap             attribute_location_to_binding_index_map;
             const Anvil::GraphicsPipelineCreateInfo*       pipeline_create_info_ptr;
             std::vector<VkVertexInputAttributeDescription> vk_input_attributes;
 

--- a/src/misc/types_struct.cpp
+++ b/src/misc/types_struct.cpp
@@ -1988,10 +1988,6 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_1D(Anvil::ImageAspectFlagBits 
 {
     MipmapRawData result;
 
-    memset(&result,
-            0,
-            sizeof(result) );
-
     result.aspect    = in_aspect;
     result.data_size = in_row_size;
     result.row_size  = in_row_size;
@@ -2015,10 +2011,6 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_1D_array(Anvil::ImageAspectFla
 {
     MipmapRawData result;
 
-    memset(&result,
-            0,
-            sizeof(result) );
-
     result.aspect    = in_aspect;
     result.data_size = in_data_size;
     result.n_layer   = in_n_layer;
@@ -2040,10 +2032,6 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_2D(Anvil::ImageAspectFlagBits 
                                                      uint32_t                   in_row_size)
 {
     MipmapRawData result;
-
-    memset(&result,
-            0,
-            sizeof(result) );
 
     result.aspect    = in_aspect;
     result.data_size = in_data_size;
@@ -2068,10 +2056,6 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_2D_array(Anvil::ImageAspectFla
 {
     MipmapRawData result;
 
-    memset(&result,
-            0,
-            sizeof(result) );
-
     result.aspect    = in_aspect;
     result.data_size = in_data_size;
     result.n_layer   = in_n_layer;
@@ -2095,10 +2079,6 @@ Anvil::MipmapRawData Anvil::MipmapRawData::create_3D(Anvil::ImageAspectFlagBits 
                                                      uint32_t                   in_row_size)
 {
     MipmapRawData result;
-
-    memset(&result,
-            0,
-            sizeof(result) );
 
     result.aspect    = in_aspect;
     result.data_size = in_data_size;

--- a/src/wrappers/buffer.cpp
+++ b/src/wrappers/buffer.cpp
@@ -296,7 +296,7 @@ bool Anvil::Buffer::init()
              */
             if (m_device_ptr->get_extension_info()->khr_get_memory_requirements2() )
             {
-                Anvil::StructID                                       dedicated_reqs_struct_id           = static_cast<Anvil::StructID>(UINT32_MAX);
+                Anvil::StructID                                       dedicated_reqs_struct_id;
                 const auto                                            gmr2_entrypoints                   = m_device_ptr->get_extension_khr_get_memory_requirements2_entrypoints();
                 VkBufferMemoryRequirementsInfo2KHR                    info;
                 const bool                                            khr_dedicated_allocation_available = m_device_ptr->get_extension_info()->khr_dedicated_allocation();

--- a/src/wrappers/descriptor_set_layout.cpp
+++ b/src/wrappers/descriptor_set_layout.cpp
@@ -94,7 +94,7 @@ uint32_t Anvil::DescriptorSetLayout::get_maximum_variable_descriptor_count(const
                                                                            const Anvil::BaseDevice*                      in_device_ptr)
 {
     const Anvil::ExtensionKHRMaintenance3Entrypoints*             entrypoints_ptr  = nullptr;
-    Anvil::StructID                                               query_struct_id  = UINT32_MAX;
+    Anvil::StructID                                               query_struct_id;
     const VkDescriptorSetVariableDescriptorCountLayoutSupportEXT* query_struct_ptr = nullptr;
     uint32_t                                                      result           = 0;
     Anvil::StructChainUniquePtr<VkDescriptorSetLayoutSupportKHR>  struct_chain_ptr;

--- a/src/wrappers/image.cpp
+++ b/src/wrappers/image.cpp
@@ -661,7 +661,7 @@ bool Anvil::Image::init()
                 Anvil::StructChainer<VkImageMemoryRequirementsInfo2KHR>        input_struct_chainer;
                 Anvil::StructChainUniquePtr<VkImageMemoryRequirementsInfo2KHR> input_struct_chain_ptr;
                 const bool                                                     khr_dedicated_allocation_available = m_device_ptr->get_extension_info()->khr_dedicated_allocation();
-                Anvil::StructID                                                memory_dedicated_reqs_struct_id    = UINT32_MAX;
+                Anvil::StructID                                                memory_dedicated_reqs_struct_id;
                 Anvil::StructChainer<VkMemoryRequirements2KHR>                 result_struct_chainer;
                 Anvil::StructChainUniquePtr<VkMemoryRequirements2KHR>          result_struct_chain_ptr;
 
@@ -735,7 +735,7 @@ bool Anvil::Image::init()
                     current_plane_properties.memory_types = memory_reqs.memoryTypeBits;
                     current_plane_properties.storage_size = memory_reqs.size;
 
-                    if (memory_dedicated_reqs_struct_id != UINT32_MAX)
+                    if (memory_dedicated_reqs_struct_id.is_valid() )
                     {
                         const auto memory_dedicated_reqs_ptr = result_struct_chain_ptr->get_struct_with_id<VkMemoryDedicatedRequirementsKHR>(memory_dedicated_reqs_struct_id);
 

--- a/src/wrappers/physical_device.cpp
+++ b/src/wrappers/physical_device.cpp
@@ -136,24 +136,24 @@ bool Anvil::PhysicalDevice::init()
 
         if (m_instance_ptr->get_enabled_extensions_info()->khr_get_physical_device_properties2() )
         {
-            Anvil::StructID                                           depth_clip_enable_features_struct_id        = UINT32_MAX;
-            Anvil::StructID                                           descriptor_indexing_features_struct_id      = UINT32_MAX;
-            Anvil::StructID                                           inline_uniform_block_features_struct_id     = UINT32_MAX;
-            Anvil::StructID                                           memory_priority_features_struct_id          = UINT32_MAX;
+            Anvil::StructID                                           depth_clip_enable_features_struct_id;
+            Anvil::StructID                                           descriptor_indexing_features_struct_id;
+            Anvil::StructID                                           inline_uniform_block_features_struct_id;
+            Anvil::StructID                                           memory_priority_features_struct_id;
             const auto&                                               gpdp2_entrypoints                           = m_instance_ptr->get_extension_khr_get_physical_device_properties2_entrypoints();
-            Anvil::StructID                                           multiview_features_struct_id                = UINT32_MAX;
-            Anvil::StructID                                           protected_memory_features_struct_id         = UINT32_MAX;
-            Anvil::StructID                                           sampler_ycbcr_conversion_features_struct_id = UINT32_MAX;
-            Anvil::StructID                                           scalar_block_layout_features_struct_id      = UINT32_MAX;
-            Anvil::StructID                                           shader_atomic_int64_features_struct_id      = UINT32_MAX;
-            Anvil::StructID                                           shader_float16_int8_struct_id               = UINT32_MAX;
-            Anvil::StructID                                           storage_features16_struct_id                = UINT32_MAX;
-            Anvil::StructID                                           storage_features8_struct_id                 = UINT32_MAX;
+            Anvil::StructID                                           multiview_features_struct_id;
+            Anvil::StructID                                           protected_memory_features_struct_id;
+            Anvil::StructID                                           sampler_ycbcr_conversion_features_struct_id;
+            Anvil::StructID                                           scalar_block_layout_features_struct_id;
+            Anvil::StructID                                           shader_atomic_int64_features_struct_id;
+            Anvil::StructID                                           shader_float16_int8_struct_id;
+            Anvil::StructID                                           storage_features16_struct_id;
+            Anvil::StructID                                           storage_features8_struct_id;
             Anvil::StructChainUniquePtr<VkPhysicalDeviceFeatures2KHR> struct_chain_ptr;
             Anvil::StructChainer<VkPhysicalDeviceFeatures2KHR>        struct_chainer;
-            Anvil::StructID                                           transform_feedback_features_struct_id       = UINT32_MAX;
-            Anvil::StructID                                           variable_pointer_features_struct_id         = UINT32_MAX;
-            Anvil::StructID                                           vulkan_memory_model_features_struct_id      = UINT32_MAX;
+            Anvil::StructID                                           transform_feedback_features_struct_id;
+            Anvil::StructID                                           variable_pointer_features_struct_id;
+            Anvil::StructID                                           vulkan_memory_model_features_struct_id;
 
             /* Chain query structs .. */
             {
@@ -327,7 +327,7 @@ bool Anvil::PhysicalDevice::init()
 
             /* Cache the results */
 
-            if (depth_clip_enable_features_struct_id != UINT32_MAX)
+            if (depth_clip_enable_features_struct_id.is_valid() )
             {
                 m_ext_depth_clip_enable_features_ptr.reset(
                     new EXTDepthClipEnableFeatures(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceDepthClipEnableFeaturesEXT>(depth_clip_enable_features_struct_id) )
@@ -342,7 +342,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (descriptor_indexing_features_struct_id != UINT32_MAX)
+            if (descriptor_indexing_features_struct_id.is_valid() )
             {
                 m_ext_descriptor_indexing_features_ptr.reset(
                     new EXTDescriptorIndexingFeatures(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceDescriptorIndexingFeaturesEXT>(descriptor_indexing_features_struct_id) )
@@ -357,7 +357,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (inline_uniform_block_features_struct_id != UINT32_MAX)
+            if (inline_uniform_block_features_struct_id.is_valid() )
             {
                 m_ext_inline_uniform_block_features_ptr.reset(
                     new EXTInlineUniformBlockFeatures(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceInlineUniformBlockFeaturesEXT>(inline_uniform_block_features_struct_id) )
@@ -372,7 +372,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (multiview_features_struct_id != UINT32_MAX)
+            if (multiview_features_struct_id.is_valid() )
             {
                 m_khr_multiview_features_ptr.reset(
                     new KHRMultiviewFeatures(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceMultiviewFeaturesKHR>(multiview_features_struct_id) )
@@ -387,7 +387,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (sampler_ycbcr_conversion_features_struct_id != UINT32_MAX)
+            if (sampler_ycbcr_conversion_features_struct_id.is_valid() )
             {
                 m_khr_sampler_ycbcr_conversion_features_ptr.reset(
                     new KHRSamplerYCbCrConversionFeatures(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceSamplerYcbcrConversionFeaturesKHR>(sampler_ycbcr_conversion_features_struct_id) )
@@ -402,7 +402,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (scalar_block_layout_features_struct_id != UINT32_MAX)
+            if (scalar_block_layout_features_struct_id.is_valid() )
             {
                 m_ext_scalar_block_layout_features_ptr.reset(
                     new EXTScalarBlockLayoutFeatures(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceScalarBlockLayoutFeaturesEXT>(scalar_block_layout_features_struct_id) )
@@ -417,7 +417,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (shader_atomic_int64_features_struct_id != UINT32_MAX)
+            if (shader_atomic_int64_features_struct_id.is_valid() )
             {
                 m_khr_shader_atomic_int64_features_ptr.reset(
                     new KHRShaderAtomicInt64Features(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceShaderAtomicInt64FeaturesKHR>(shader_atomic_int64_features_struct_id) )
@@ -432,7 +432,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (transform_feedback_features_struct_id != UINT32_MAX)
+            if (transform_feedback_features_struct_id.is_valid() )
             {
                 m_ext_transform_feedback_features_ptr.reset(
                     new EXTTransformFeedbackFeatures(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceTransformFeedbackFeaturesEXT>(transform_feedback_features_struct_id) )
@@ -447,7 +447,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (storage_features16_struct_id != UINT32_MAX)
+            if (storage_features16_struct_id.is_valid() )
             {
                 m_khr_16_bit_storage_features_ptr.reset(
                     new KHR16BitStorageFeatures(*struct_chain_ptr->get_struct_with_id<VkPhysicalDevice16BitStorageFeaturesKHR>(storage_features16_struct_id) )
@@ -462,7 +462,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (storage_features8_struct_id != UINT32_MAX)
+            if (storage_features8_struct_id.is_valid() )
             {
                 m_khr_8_bit_storage_features_ptr.reset(
                     new KHR8BitStorageFeatures(*struct_chain_ptr->get_struct_with_id<VkPhysicalDevice8BitStorageFeaturesKHR>(storage_features8_struct_id) )
@@ -477,7 +477,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (memory_priority_features_struct_id != UINT32_MAX)
+            if (memory_priority_features_struct_id.is_valid() )
             {
                 m_ext_memory_priority_features_ptr.reset(
                     new EXTMemoryPriorityFeatures(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceMemoryPriorityFeaturesEXT>(memory_priority_features_struct_id))
@@ -492,7 +492,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (shader_float16_int8_struct_id != UINT32_MAX)
+            if (shader_float16_int8_struct_id.is_valid() )
             {
                 m_khr_float16_int8_features_ptr.reset(
                     new KHRFloat16Int8Features(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceFloat16Int8FeaturesKHR>(shader_float16_int8_struct_id) )
@@ -507,7 +507,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (variable_pointer_features_struct_id != UINT32_MAX)
+            if (variable_pointer_features_struct_id.is_valid() )
             {
                 m_khr_variable_pointer_features_ptr.reset(
                     new KHRVariablePointerFeatures(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceVariablePointerFeaturesKHR>(variable_pointer_features_struct_id) )
@@ -522,7 +522,7 @@ bool Anvil::PhysicalDevice::init()
                 }
             }
 
-            if (vulkan_memory_model_features_struct_id != UINT32_MAX)
+            if (vulkan_memory_model_features_struct_id.is_valid() )
             {
                 m_khr_vulkan_memory_model_features_ptr.reset(
                     new KHRVulkanMemoryModelFeatures(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceVulkanMemoryModelFeaturesKHR>(vulkan_memory_model_features_struct_id) )
@@ -647,28 +647,28 @@ bool Anvil::PhysicalDevice::init()
     /* Retrieve additional device info */
     if (m_instance_ptr->get_enabled_extensions_info()->khr_get_physical_device_properties2() )
     {
-        Anvil::StructID                                             conservative_rasterization_struct_id     = UINT32_MAX;
-        Anvil::StructID                                             depth_stencil_resolve_props_struct_id    = UINT32_MAX;
-        Anvil::StructID                                             descriptor_indexing_props_struct_id      = UINT32_MAX;
-        Anvil::StructID                                             device_id_props_struct_id                = UINT32_MAX;
-        Anvil::StructID                                             driver_properties_props_struct_id        = UINT32_MAX;
-        Anvil::StructID                                             external_memory_host_props_struct_id     = UINT32_MAX;
+        Anvil::StructID                                             conservative_rasterization_struct_id;
+        Anvil::StructID                                             depth_stencil_resolve_props_struct_id;
+        Anvil::StructID                                             descriptor_indexing_props_struct_id;
+        Anvil::StructID                                             device_id_props_struct_id;
+        Anvil::StructID                                             driver_properties_props_struct_id;
+        Anvil::StructID                                             external_memory_host_props_struct_id;
         const auto&                                                 gpdp2_entrypoints                        = m_instance_ptr->get_extension_khr_get_physical_device_properties2_entrypoints();
-        Anvil::StructID                                             inline_uniform_block_props_struct_id     = UINT32_MAX;
-        Anvil::StructID                                             maintenance3_struct_id                   = UINT32_MAX;
-        Anvil::StructID                                             multiview_struct_id                      = UINT32_MAX;
-        Anvil::StructID                                             pci_bus_info_props_struct_id             = UINT32_MAX;
-        Anvil::StructID                                             point_clipping_props_struct_id           = UINT32_MAX;
-        Anvil::StructID                                             protected_memory_props_struct_id         = UINT32_MAX;
-        Anvil::StructID                                             sample_locations_props_struct_id         = UINT32_MAX;
-        Anvil::StructID                                             sampler_filter_minmax_props_struct_id    = UINT32_MAX;
-        Anvil::StructID                                             shader_core_struct_id                    = UINT32_MAX;
-        Anvil::StructID                                             shader_float_controls_props_struct_id    = UINT32_MAX;
+        Anvil::StructID                                             inline_uniform_block_props_struct_id;
+        Anvil::StructID                                             maintenance3_struct_id;
+        Anvil::StructID                                             multiview_struct_id;
+        Anvil::StructID                                             pci_bus_info_props_struct_id;
+        Anvil::StructID                                             point_clipping_props_struct_id;
+        Anvil::StructID                                             protected_memory_props_struct_id;
+        Anvil::StructID                                             sample_locations_props_struct_id;
+        Anvil::StructID                                             sampler_filter_minmax_props_struct_id;
+        Anvil::StructID                                             shader_core_struct_id;
+        Anvil::StructID                                             shader_float_controls_props_struct_id;
         Anvil::StructChainUniquePtr<VkPhysicalDeviceProperties2KHR> struct_chain_ptr;
         Anvil::StructChainer<VkPhysicalDeviceProperties2KHR>        struct_chainer;
-        Anvil::StructID                                             subgroup_props_struct_id                 = UINT32_MAX;
-        Anvil::StructID                                             transform_feedback_props_struct_id       = UINT32_MAX;
-        Anvil::StructID                                             vertex_attribute_divisor_props_struct_id = UINT32_MAX;
+        Anvil::StructID                                             subgroup_props_struct_id;
+        Anvil::StructID                                             transform_feedback_props_struct_id;
+        Anvil::StructID                                             vertex_attribute_divisor_props_struct_id;
 
         /* Chain query structs */
         {
@@ -891,7 +891,7 @@ bool Anvil::PhysicalDevice::init()
         }
 
         /* Cache the retrieved properties */
-        if (conservative_rasterization_struct_id != UINT32_MAX)
+        if (conservative_rasterization_struct_id.is_valid() )
         {
             m_ext_conservative_rasterization_properties_ptr.reset(
                 new EXTConservativeRasterizationProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceConservativeRasterizationPropertiesEXT>(conservative_rasterization_struct_id) )
@@ -906,7 +906,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (depth_stencil_resolve_props_struct_id != UINT32_MAX)
+        if (depth_stencil_resolve_props_struct_id.is_valid() )
         {
             m_khr_depth_stencil_resolve_properties_ptr.reset(
                 new KHRDepthStencilResolveProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceDepthStencilResolvePropertiesKHR>(depth_stencil_resolve_props_struct_id) )
@@ -921,7 +921,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (descriptor_indexing_props_struct_id != UINT32_MAX)
+        if (descriptor_indexing_props_struct_id.is_valid() )
         {
             m_ext_descriptor_indexing_properties_ptr.reset(
                 new EXTDescriptorIndexingProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceDescriptorIndexingPropertiesEXT>(descriptor_indexing_props_struct_id) )
@@ -936,7 +936,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (driver_properties_props_struct_id != UINT32_MAX)
+        if (driver_properties_props_struct_id.is_valid() )
         {
             m_khr_driver_properties_properties_ptr.reset(
                 new KHRDriverPropertiesProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceDriverPropertiesKHR>(driver_properties_props_struct_id) )
@@ -951,7 +951,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (device_id_props_struct_id != UINT32_MAX)
+        if (device_id_props_struct_id.is_valid() )
         {
             m_khr_external_memory_capabilities_physical_device_id_properties_ptr.reset(
                 new KHRExternalMemoryCapabilitiesPhysicalDeviceIDProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceIDPropertiesKHR>(device_id_props_struct_id) )
@@ -966,7 +966,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (external_memory_host_props_struct_id != UINT32_MAX)
+        if (external_memory_host_props_struct_id.is_valid() )
         {
             m_ext_external_memory_host_properties_ptr.reset(
                 new EXTExternalMemoryHostProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceExternalMemoryHostPropertiesEXT>(external_memory_host_props_struct_id) )
@@ -981,7 +981,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (inline_uniform_block_props_struct_id != UINT32_MAX)
+        if (inline_uniform_block_props_struct_id.is_valid() )
         {
             m_ext_inline_uniform_block_properties_ptr.reset(
                 new EXTInlineUniformBlockProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceInlineUniformBlockPropertiesEXT>(inline_uniform_block_props_struct_id) )
@@ -996,7 +996,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (maintenance3_struct_id != UINT32_MAX)
+        if (maintenance3_struct_id.is_valid() )
         {
             m_khr_maintenance3_properties_ptr.reset(
                 new KHRMaintenance3Properties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceMaintenance3PropertiesKHR>(maintenance3_struct_id) )
@@ -1011,7 +1011,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (multiview_struct_id != UINT32_MAX)
+        if (multiview_struct_id.is_valid() )
         {
             m_khr_multiview_properties_ptr.reset(
                 new KHRMultiviewProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceMultiviewPropertiesKHR>(multiview_struct_id) )
@@ -1026,7 +1026,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (pci_bus_info_props_struct_id != UINT32_MAX)
+        if (pci_bus_info_props_struct_id.is_valid() )
         {
             m_ext_pci_bus_info_ptr.reset(
                 new EXTPCIBusInfoProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDevicePCIBusInfoPropertiesEXT>(pci_bus_info_props_struct_id) )
@@ -1041,7 +1041,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (point_clipping_props_struct_id != UINT32_MAX)
+        if (point_clipping_props_struct_id.is_valid() )
         {
             m_khr_maintenance2_physical_device_point_clipping_properties_ptr.reset(
                 new KHRMaintenance2PhysicalDevicePointClippingProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDevicePointClippingPropertiesKHR>(point_clipping_props_struct_id))
@@ -1056,7 +1056,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (sample_locations_props_struct_id != UINT32_MAX)
+        if (sample_locations_props_struct_id.is_valid() )
         {
             m_ext_sample_locations_properties_ptr.reset(
                 new EXTSampleLocationsProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceSampleLocationsPropertiesEXT>(sample_locations_props_struct_id) )
@@ -1071,7 +1071,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (sampler_filter_minmax_props_struct_id != UINT32_MAX)
+        if (sampler_filter_minmax_props_struct_id.is_valid() )
         {
             m_ext_sampler_filter_minmax_properties_ptr.reset(
                 new EXTSamplerFilterMinmaxProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT>(sampler_filter_minmax_props_struct_id) )
@@ -1086,7 +1086,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (shader_core_struct_id != UINT32_MAX)
+        if (shader_core_struct_id.is_valid() )
         {
             m_amd_shader_core_properties_ptr.reset(
                 new AMDShaderCoreProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceShaderCorePropertiesAMD>(shader_core_struct_id) )
@@ -1101,7 +1101,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (shader_float_controls_props_struct_id != UINT32_MAX)
+        if (shader_float_controls_props_struct_id.is_valid() )
         {
             m_khr_shader_float_controls_properties_ptr.reset(
                 new KHRShaderFloatControlsProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceFloatControlsPropertiesKHR>(shader_float_controls_props_struct_id) )
@@ -1116,7 +1116,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (transform_feedback_props_struct_id != UINT32_MAX)
+        if (transform_feedback_props_struct_id.is_valid() )
         {
             m_ext_transform_feedback_properties_ptr.reset(
                 new EXTTransformFeedbackProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceTransformFeedbackPropertiesEXT>(transform_feedback_props_struct_id) )
@@ -1131,7 +1131,7 @@ bool Anvil::PhysicalDevice::init()
             }
         }
 
-        if (vertex_attribute_divisor_props_struct_id != UINT32_MAX)
+        if (vertex_attribute_divisor_props_struct_id.is_valid() )
         {
             m_ext_vertex_attribute_divisor_properties_ptr.reset(
                 new EXTVertexAttributeDivisorProperties(*struct_chain_ptr->get_struct_with_id<VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT>(vertex_attribute_divisor_props_struct_id) )
@@ -1369,13 +1369,13 @@ bool Anvil::PhysicalDevice::get_image_format_properties(const ImageFormatPropert
 
     if (gpdp2_entrypoints_ptr != nullptr)
     {
-        Anvil::StructID                                           external_image_format_props_struct_id                 = UINT32_MAX;
-        Anvil::StructID                                           image_stencil_usage_create_info_struct_id             = UINT32_MAX;
+        Anvil::StructID                                           external_image_format_props_struct_id;
+        Anvil::StructID                                           image_stencil_usage_create_info_struct_id;
         Anvil::StructChainer<VkPhysicalDeviceImageFormatInfo2KHR> input_struct_chainer;
         auto                                                      instance_extensions_ptr                               = m_instance_ptr->get_enabled_extensions_info();
         Anvil::StructChainer<VkImageFormatProperties2KHR>         output_struct_chainer;
-        Anvil::StructID                                           sampler_ycbcr_conversion_image_format_props_struct_id = UINT32_MAX; 
-        Anvil::StructID                                           texture_lod_gather_support_struct_id                  = UINT32_MAX;
+        Anvil::StructID                                           sampler_ycbcr_conversion_image_format_props_struct_id;
+        Anvil::StructID                                           texture_lod_gather_support_struct_id;
 
         ANVIL_REDUNDANT_VARIABLE(instance_extensions_ptr);
 
@@ -1476,14 +1476,14 @@ bool Anvil::PhysicalDevice::get_image_format_properties(const ImageFormatPropert
                 external_handle_props = Anvil::ExternalMemoryProperties(image_format_props_ptr->externalMemoryProperties);
             }
 
-            if (image_stencil_usage_create_info_struct_id != UINT32_MAX)
+            if (image_stencil_usage_create_info_struct_id.is_valid() )
             {
                 auto stencil_usage_create_info_ptr = reinterpret_cast<const VkImageStencilUsageCreateInfoEXT*>(input_struct_chain_ptr->get_struct_with_id(image_stencil_usage_create_info_struct_id) );
 
                 valid_stencil_image_usage_aspect_flags = static_cast<Anvil::ImageUsageFlagBits>(stencil_usage_create_info_ptr->stencilUsage);
             }
 
-            if (sampler_ycbcr_conversion_image_format_props_struct_id != UINT32_MAX)
+            if (sampler_ycbcr_conversion_image_format_props_struct_id.is_valid() )
             {
                 auto image_format_props_ptr = reinterpret_cast<const VkSamplerYcbcrConversionImageFormatPropertiesKHR*>(input_struct_chain_ptr->get_struct_with_id(sampler_ycbcr_conversion_image_format_props_struct_id) );
 


### PR DESCRIPTION
Fix #134: Assertion failure when using specialization constants
Address #18: Add CMake option to use alternative glslang snapshot
Address #75: Replace in_releaseable_sets wioth descriptor pool create flags in DescriptorSetGroup::create()
Address #104: Pipeline cache to use for a particular device can now be specified in DeviceCreateInfo.
Address #59: Change add_vertex_attribute() to add_vertex_binding()