### PR TITLE
Addressed string conversion warning introduced in VS 2019.

### DIFF
--- a/src/misc/io.cpp
+++ b/src/misc/io.cpp
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <codecvt>
 
 #ifdef _WIN32
     #include <Windows.h>
@@ -165,7 +166,7 @@ bool Anvil::IO::enumerate_files_in_directory(const std::string&        in_path,
                 {
                     std::wstring file_name_wide          (find_data.cFileName);
                     std::wstring file_name_with_path_wide(current_path_wide + file_name_wide);
-                    std::string  file_name               (file_name_with_path_wide.begin(), file_name_with_path_wide.end() );
+					std::string file_name = std::wstring_convert<std::codecvt_utf8<wchar_t>>().to_bytes(file_name_with_path_wide);
 
                     out_result_ptr->push_back(file_name);
                 }


### PR DESCRIPTION
Building with VS 2019 issues a C4244 warning from io.cpp line 168:  conversion from wchar_t to const_Eem, possible loss of data.

In the pull request, I used codecvt_utf8 to address the warning. While codecvt is deprecated in C++17, it'll remain valid until a replacement is found.